### PR TITLE
In get_blob_properties of blob_service, use :head instead of :get

### DIFF
--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -776,7 +776,7 @@ module Azure
 
         uri = blob_uri(container, blob, query)
 
-        response = call(:get, uri)
+        response = call(:head, uri)
 
         result = Serialization.blob_from_headers(response.headers)
 


### PR DESCRIPTION
According to:

http://msdn.microsoft.com/en-us/library/windowsazure/dd179394.aspx

one should use HEAD method to get blob properties. However, in the get_blob_properties method of

lib/azure/blob/blob_service.rb

:get was used instead of :head. The drawback is that when an entire blob is downloaded for getting the blob properties. Calling :head avoids it.
