### PR TITLE
fix empty response body handling

### DIFF
--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -776,7 +776,7 @@ module Azure
 
         uri = blob_uri(container, blob, query)
 
-        response = call(:get, uri)
+        response = call(:head, uri)
 
         result = Serialization.blob_from_headers(response.headers)
 

--- a/lib/azure/core/http/http_error.rb
+++ b/lib/azure/core/http/http_error.rb
@@ -61,7 +61,7 @@ module Azure
         #
         # Returns nothing
         def parse_response
-          if @http_response.body.include?("<")
+          if @http_response.body && @http_response.body.include?("<")
 
             document = Nokogiri.Slop(@http_response.body)
 
@@ -75,7 +75,11 @@ module Azure
             @detail = document.css("Detail").first.text if document.css("Detail").any?
           else
             @type = "Unknown"
-            @description = @http_response.body.strip
+            if @http_response.body
+              @description = @http_response.body.strip
+            else
+              @description = @http_response.message.strip
+            end
           end
         end
       end

--- a/lib/azure/core/http/http_response.rb
+++ b/lib/azure/core/http/http_response.rb
@@ -37,6 +37,13 @@ module Azure
           @http_response.body
         end
 
+        # Public: Get the response status message.
+        #
+        # Returns a String.
+        def message
+          @http_response.message
+        end
+
         # Public: Get the response status code.
         #
         # Returns a Fixnum.


### PR DESCRIPTION
In get_blob_properties of blob_service, use get is critical.
I try to use  #59 fix, but not works.
I add more little more fix.
