### PR TITLE
Improve the RetryPolicy filter

### DIFF
--- a/lib/azure/core/http/retry_policy.rb
+++ b/lib/azure/core/http/retry_policy.rb
@@ -39,8 +39,8 @@ module Azure
           response = nil
           begin
             response = _next.call
-          rescue StandardError => e
-            retry if should_retry?(response, retry_data)
+          rescue StandardError => error
+            retry if should_retry?(error, retry_data)
           end
           response
         end
@@ -61,8 +61,8 @@ module Azure
         # constructor the method returns false.
         #
         # Alternatively, a subclass could override this method.
-        def should_retry?(response, retry_data)
-          @block ? @block.call(response, retry_data) : false
+        def should_retry?(error, retry_data)
+          @block ? @block.call(error, retry_data) : false
         end
       end
     end


### PR DESCRIPTION
- Fix the require. Without this adjustment the retry policy is unusable on most systems, since the path will be incorrect and the require will fail.
- Use another mechanism for retrying.
- Pass the error instead of result to retry block.

_Note_
I still have trouble getting this to work, so perhaps someone on the team can chip in and add commits to make this filter usable.
