### PR TITLE
Enable parsing of EnqueuedTimeUtc given its new serialization format

### DIFF
--- a/lib/azure/service_bus/brokered_message_serializer.rb
+++ b/lib/azure/service_bus/brokered_message_serializer.rb
@@ -66,7 +66,8 @@ module Azure
 
           # Time based properties
           m.locked_until_utc            = Time.parse(props['LockedUntilUtc']) unless props['LockedUntilUtc'].nil?
-          m.enqueued_time_utc           = Time.parse(props['EnqueuedTimeUtc']) unless props['EnqueuedTimeUtc'].nil?
+          enqueued_time_utc             = self.parse_dot_net_serialized_datetime(props['EnqueuedTimeUtc']) unless props['EnqueuedTimeUtc'].nil?
+          m.enqueued_time_utc           = enqueued_time_utc unless enqueued_time_utc.nil?
           m.scheduled_enqueue_time_utc  = Time.parse(props['ScheduledEnqueueTimeUtc']) unless props['ScheduledEnqueueTimeUtc'].nil?
 
           # Numeric based properties
@@ -121,6 +122,23 @@ module Azure
           hash[name] = tmp[1..(tmp.length-2)]
         end
         hash
+      end
+
+      private
+
+      # Take the .net json serialization of a DateTime (i.e. /Date(...)/)
+      # and return a time object
+      #
+      # Returns a Time instance
+      def self.parse_dot_net_serialized_datetime(datetime)
+        milliseconds_in_second = 1000
+        match = /\/Date\((\d+)\)\//.match(datetime)
+        if !match.nil?
+          ticks = match[1].to_i
+          time = Time.at(ticks / milliseconds_in_second)
+        else
+          nil
+        end
       end
     end
   end

--- a/test/integration/service_bus/scenario_test.rb
+++ b/test/integration/service_bus/scenario_test.rb
@@ -58,7 +58,6 @@ class ScenarioHelper
     actual.body.must_equal                       expected.body
     actual.content_type.must_equal               expected.content_type
     actual.correlation_id.must_equal             expected.correlation_id
-    actual.enqueued_time_utc.must_equal          expected.enqueued_time_utc
     actual.label.must_equal                      expected.label
     actual.message_id.must_equal                 expected.message_id
     actual.reply_to.must_equal                   expected.reply_to
@@ -71,6 +70,7 @@ class ScenarioHelper
     # so we cannot verify as much
     actual.delivery_count.must_be :kind_of?, Integer
     actual.sequence_number.must_be :kind_of?, Integer
+    actual.enqueued_time_utc.must_be :kind_of?, Time
     if actual.lock_token != nil
       actual.lock_token.must_be :kind_of?, String
     end


### PR DESCRIPTION
Opening a new pull request to retarget dev branch, as discussed in https://github.com/WindowsAzure/azure-sdk-for-ruby/pull/93
