### PR TITLE
do not pollute root namespace

### DIFF
--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -23,7 +23,7 @@ require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
 include Azure::Core::Utility
-Loggerx = Azure::Core::Logger
+Azure::Loggerx = Azure::Core::Logger
 
 module Azure
   module BaseManagement
@@ -131,7 +131,7 @@ module Azure
           request_path = '/affinitygroups'
           request = ManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Loggerx.info "Affinity Group #{name} is created."
+          Azure::Loggerx.info "Affinity Group #{name} is created."
         end
       end
 
@@ -160,7 +160,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:put, request_path, body)
           request.call
-          Loggerx.info "Affinity Group #{name} is updated."
+          Azure::Loggerx.info "Affinity Group #{name} is updated."
         end
       end
 
@@ -178,7 +178,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted affinity group #{name}."
+          Azure::Loggerx.info "Deleted affinity group #{name}."
         end
       end
 

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -22,7 +22,6 @@ require 'azure/base_management/serialization'
 require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
-include Azure::Core::Utility
 Azure::Loggerx = Azure::Core::Logger
 
 module Azure

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -22,7 +22,6 @@ require 'azure/base_management/serialization'
 require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
-include Azure::BaseManagement
 include Azure::Core::Utility
 Loggerx = Azure::Core::Logger
 

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -130,7 +130,7 @@ module Azure
           request_path = '/affinitygroups'
           request = ManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Azure::Loggerx.info "Affinity Group #{name} is created."
+          Loggerx.info "Affinity Group #{name} is created."
         end
       end
 
@@ -159,7 +159,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:put, request_path, body)
           request.call
-          Azure::Loggerx.info "Affinity Group #{name} is updated."
+          Loggerx.info "Affinity Group #{name} is updated."
         end
       end
 
@@ -177,7 +177,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted affinity group #{name}."
+          Loggerx.info "Deleted affinity group #{name}."
         end
       end
 

--- a/lib/azure/base_management/management_http_request.rb
+++ b/lib/azure/base_management/management_http_request.rb
@@ -66,7 +66,7 @@ module Azure
       def wait_for_completion(response)
         ret_val = Nokogiri::XML response.body
         if ret_val.at_css('Error Code') && ret_val.at_css('Error Code').content == 'AuthenticationFailed'
-          Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         end
         if response.status_code.to_i == 200 || response.status_code.to_i == 201
           return response
@@ -75,15 +75,15 @@ module Azure
         elsif response.status_code.to_i > 201 && response.status_code.to_i <= 299
           check_completion(response.headers['x-ms-request-id'])
         elsif warn && !response.success?
-          # Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          # Azure::Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         elsif response.body
           if ret_val.at_css('Error Code') && ret_val.at_css('Error Message')
-            Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+            Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
           else
-            Loggerx.exception_message "http error: #{response.status_code}"
+            Azure::Loggerx.exception_message "http error: #{response.status_code}"
           end
         else
-          Loggerx.exception_message "http error: #{response.status_code}"
+          Azure::Loggerx.exception_message "http error: #{response.status_code}"
         end
       end
 
@@ -122,9 +122,9 @@ module Azure
             if status.downcase != 'succeeded'
               error_code = xml_content(ret_val, 'Operation Error Code')
               error_msg = xml_content(ret_val, 'Operation Error Message')
-              Loggerx.exception_message "#{error_code}: #{error_msg}"
+              Azure::Loggerx.exception_message "#{error_code}: #{error_msg}"
             else
-              Loggerx.success "#{status.downcase} (#{status_code})"
+              Azure::Loggerx.success "#{status.downcase} (#{status_code})"
             end
             return
           else

--- a/lib/azure/base_management/management_http_request.rb
+++ b/lib/azure/base_management/management_http_request.rb
@@ -66,7 +66,7 @@ module Azure
       def wait_for_completion(response)
         ret_val = Nokogiri::XML response.body
         if ret_val.at_css('Error Code') && ret_val.at_css('Error Code').content == 'AuthenticationFailed'
-          Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         end
         if response.status_code.to_i == 200 || response.status_code.to_i == 201
           return response
@@ -75,15 +75,15 @@ module Azure
         elsif response.status_code.to_i > 201 && response.status_code.to_i <= 299
           check_completion(response.headers['x-ms-request-id'])
         elsif warn && !response.success?
-          # Azure::Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          # Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         elsif response.body
           if ret_val.at_css('Error Code') && ret_val.at_css('Error Message')
-            Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+            Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
           else
-            Azure::Loggerx.exception_message "http error: #{response.status_code}"
+            Loggerx.exception_message "http error: #{response.status_code}"
           end
         else
-          Azure::Loggerx.exception_message "http error: #{response.status_code}"
+          Loggerx.exception_message "http error: #{response.status_code}"
         end
       end
 
@@ -122,9 +122,9 @@ module Azure
             if status.downcase != 'succeeded'
               error_code = xml_content(ret_val, 'Operation Error Code')
               error_msg = xml_content(ret_val, 'Operation Error Message')
-              Azure::Loggerx.exception_message "#{error_code}: #{error_msg}"
+              Loggerx.exception_message "#{error_code}: #{error_msg}"
             else
-              Azure::Loggerx.success "#{status.downcase} (#{status_code})"
+              Loggerx.success "#{status.downcase} (#{status_code})"
             end
             return
           else

--- a/lib/azure/base_management/serialization.rb
+++ b/lib/azure/base_management/serialization.rb
@@ -16,6 +16,7 @@
 module Azure
   module BaseManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.locations_from_xml(locationXML)
         location_objs = []
         xml = locationXML.css('Locations Location')

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -48,11 +48,11 @@ module Azure
       #
       # Returns None
       def create_cloud_service(name, options = {})
-        Azure::Loggerx.error_with_exit "Cloud service name is not valid " unless name
+        Loggerx.error_with_exit "Cloud service name is not valid " unless name
         if get_cloud_service(name)
-          Azure::Loggerx.warn "Cloud service #{name} already exists. Skipped..."
+          Loggerx.warn "Cloud service #{name} already exists. Skipped..."
         else
-          Azure::Loggerx.info "Creating cloud service #{name}."
+          Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -101,7 +101,7 @@ module Azure
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Azure::Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
+        Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
 
@@ -117,7 +117,7 @@ module Azure
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Azure::Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
+        Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
 
@@ -125,7 +125,7 @@ module Azure
         data = export_der(ssh[:cert], ssh[:key])
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
         body = BaseManagement::Serialization.add_certificate_to_xml(data)
-        Azure::Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
+        Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
         request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -16,7 +16,7 @@ require 'azure/cloud_service_management/serialization'
 
 module Azure
   module CloudServiceManagement
-    class CloudServiceManagementService < BaseManagementService
+    class CloudServiceManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -55,7 +55,7 @@ module Azure
           Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
-          request = ManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
           request.call
         end
       end
@@ -65,7 +65,7 @@ module Azure
       # Returns an array of Azure::CloudServiceManagement::CloudService objects
       def list_cloud_services
         request_path = "/services/hostedservices"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.cloud_services_from_xml(response)
       end
@@ -100,7 +100,7 @@ module Azure
       # Returns:  None
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
@@ -116,7 +116,7 @@ module Azure
       # Returns NONE
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
@@ -126,7 +126,7 @@ module Azure
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
         body = Serialization.add_certificate_to_xml(data)
         Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
-        request = ManagementHttpRequest.new(:post, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end
 

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -48,11 +48,11 @@ module Azure
       #
       # Returns None
       def create_cloud_service(name, options = {})
-        Loggerx.error_with_exit "Cloud service name is not valid " unless name
+        Azure::Loggerx.error_with_exit "Cloud service name is not valid " unless name
         if get_cloud_service(name)
-          Loggerx.warn "Cloud service #{name} already exists. Skipped..."
+          Azure::Loggerx.warn "Cloud service #{name} already exists. Skipped..."
         else
-          Loggerx.info "Creating cloud service #{name}."
+          Azure::Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -101,7 +101,7 @@ module Azure
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
+        Azure::Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
 
@@ -117,15 +117,15 @@ module Azure
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
+        Azure::Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
 
       def upload_certificate(cloud_service_name, ssh)
         data = export_der(ssh[:cert], ssh[:key])
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
-        body = Serialization.add_certificate_to_xml(data)
-        Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
+        body = BaseManagement::Serialization.add_certificate_to_xml(data)
+        Azure::Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
         request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end

--- a/lib/azure/cloud_service_management/serialization.rb
+++ b/lib/azure/cloud_service_management/serialization.rb
@@ -18,6 +18,7 @@ require 'azure/cloud_service_management/cloud_service'
 module Azure
   module CloudServiceManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.cloud_services_to_xml(name, options = {})
         options[:label] = options[:label] || name
 

--- a/lib/azure/core/utility.rb
+++ b/lib/azure/core/utility.rb
@@ -60,7 +60,7 @@ module Azure
         elsif File.exist?(File.join(ENV['HOME'], name))
           File.join(ENV['HOME'], name)
         else
-          Azure::Loggerx.error_with_exit "Unable to find #{name} file  "
+          Loggerx.error_with_exit "Unable to find #{name} file  "
         end
       end
 

--- a/lib/azure/core/utility.rb
+++ b/lib/azure/core/utility.rb
@@ -60,7 +60,7 @@ module Azure
         elsif File.exist?(File.join(ENV['HOME'], name))
           File.join(ENV['HOME'], name)
         else
-          Loggerx.error_with_exit "Unable to find #{name} file  "
+          Azure::Loggerx.error_with_exit "Unable to find #{name} file  "
         end
       end
 

--- a/lib/azure/sql_database_management/serialization.rb
+++ b/lib/azure/sql_database_management/serialization.rb
@@ -17,6 +17,7 @@ require 'azure/sql_database_management/sql_database'
 module Azure
   module SqlDatabaseManagement
     module Serialization
+      extend Azure::Core::Utility
 
       def self.database_to_xml(login, password, location)
         builder = Nokogiri::XML::Builder.new do |xml|

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -16,7 +16,7 @@ require 'azure/sql_database_management/serialization'
 
 module Azure
   module SqlDatabaseManagement
-    class SqlDatabaseManagementService < BaseManagementService
+    class SqlDatabaseManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -30,7 +30,7 @@ module Azure
       # Returns an array of Azure::SqlDatabaseManagement::SqlDatabase objects
       def list_servers
         request_path = '/servers'
-        request = SqlManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::SqlManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.databases_from_xml(response)
       end
@@ -49,7 +49,7 @@ module Azure
       def create_server(login, password, location)
         body = Serialization.database_to_xml(login, password, location)
         request_path = '/servers'
-        request = SqlManagementHttpRequest.new(:post, request_path, body)
+        request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
         Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
@@ -69,7 +69,7 @@ module Azure
       def delete_server(name)
         if get_sql_server(name)
           request_path = "/servers/#{name}"
-          request = SqlManagementHttpRequest.new(:delete, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
           Loggerx.info "Deleted database server #{name}."
         end
@@ -90,7 +90,7 @@ module Azure
         if get_sql_server(name)
           body = Serialization.reset_password_to_xml(password)
           request_path = "/servers/#{name}?op=ResetPassword"
-          request = SqlManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
           Loggerx.info "Password for server #{name} changed successfully."
         end
@@ -127,7 +127,7 @@ module Azure
             request_path = "/servers/#{server_name}/firewallrules/#{rule_name}?op=AutoDetectClientIP"
             method = :post
           end
-          request = SqlManagementHttpRequest.new(method, request_path, body)
+          request = BaseManagement::SqlManagementHttpRequest.new(method, request_path, body)
           request.headers['x-ms-version'] = '1.0'
           request.uri = URI.parse(Azure.config.sql_database_management_endpoint + Azure.config.subscription_id + request_path)
           # Management certificate authentication Endpoint throws errors for this operation. Need to re-visit
@@ -151,7 +151,7 @@ module Azure
       def list_sql_server_firewall_rules(server_name)
         if get_sql_server(server_name)
           request_path = "/servers/#{server_name}/firewallrules"
-          request = SqlManagementHttpRequest.new(:get, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:get, request_path)
           response = request.call
           Serialization.database_firewall_from_xml(response)
         end
@@ -173,7 +173,7 @@ module Azure
           raise error
         elsif get_sql_server(server_name)
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
-          request = SqlManagementHttpRequest.new(:delete, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
           Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -52,7 +52,7 @@ module Azure
         request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
-        Azure::Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
+        Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
         sql_server
       end
 
@@ -71,7 +71,7 @@ module Azure
           request_path = "/servers/#{name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted database server #{name}."
+          Loggerx.info "Deleted database server #{name}."
         end
       end
 
@@ -92,7 +92,7 @@ module Azure
           request_path = "/servers/#{name}?op=ResetPassword"
           request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Azure::Loggerx.info "Password for server #{name} changed successfully."
+          Loggerx.info "Password for server #{name} changed successfully."
         end
       end
 
@@ -134,7 +134,7 @@ module Azure
           # this once the Azure API is working.
 
           request.call
-          Azure::Loggerx.info "Added server-level firewall rule #{rule_name}."
+          Loggerx.info "Added server-level firewall rule #{rule_name}."
         end
       end
 
@@ -175,7 +175,7 @@ module Azure
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted server-level firewall rule #{rule_name}."
+          Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end
       end
 

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -52,7 +52,7 @@ module Azure
         request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
-        Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
+        Azure::Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
         sql_server
       end
 
@@ -71,7 +71,7 @@ module Azure
           request_path = "/servers/#{name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted database server #{name}."
+          Azure::Loggerx.info "Deleted database server #{name}."
         end
       end
 
@@ -92,7 +92,7 @@ module Azure
           request_path = "/servers/#{name}?op=ResetPassword"
           request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Loggerx.info "Password for server #{name} changed successfully."
+          Azure::Loggerx.info "Password for server #{name} changed successfully."
         end
       end
 
@@ -134,7 +134,7 @@ module Azure
           # this once the Azure API is working.
 
           request.call
-          Loggerx.info "Added server-level firewall rule #{rule_name}."
+          Azure::Loggerx.info "Added server-level firewall rule #{rule_name}."
         end
       end
 
@@ -175,7 +175,7 @@ module Azure
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted server-level firewall rule #{rule_name}."
+          Azure::Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end
       end
 

--- a/lib/azure/storage_management/serialization.rb
+++ b/lib/azure/storage_management/serialization.rb
@@ -20,6 +20,7 @@ module Azure
     # Storage management serialization module is responsible for converting
     # the objects to XML and vice versa.
     module Serialization
+      extend Azure::Core::Utility
       def self.storage_services_to_xml(name, options = {})
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.CreateStorageServiceInput(

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -99,9 +99,9 @@ module Azure
       def create_storage_account(name, options = {})
         raise 'Name not specified' if !name || name.class != String || name.empty?
         if get_storage_account(name)
-          Azure::Loggerx.warn "Storage Account #{name} already exists. Skipped..."
+          Loggerx.warn "Storage Account #{name} already exists. Skipped..."
         else
-          Azure::Loggerx.info "Creating Storage Account #{name}."
+          Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -135,13 +135,13 @@ module Azure
       # Fails with RuntimeError if invalid options specified
       def update_storage_account(name, options = {})
         if get_storage_account name
-          Azure::Loggerx.info "Account '#{name}' exists, updating..."
+          Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
           request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
-          Azure::Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
+          Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
         end
       end
 
@@ -154,7 +154,7 @@ module Azure
       #
       # Returns:  None
       def delete_storage_account(name)
-        Azure::Loggerx.info "Deleting Storage Account #{name}."
+        Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -17,7 +17,7 @@ require 'azure/storage_management/serialization'
 module Azure
   module StorageManagement
     # Provides Storage Management API
-    class StorageManagementService < BaseManagementService
+    class StorageManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -27,7 +27,7 @@ module Azure
       # Returns an array of Azure::StorageManagement::StorageAccount objects
       def list_storage_accounts
         request_path = '/services/storageservices'
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.storage_services_from_xml(response)
       end
@@ -65,7 +65,7 @@ module Azure
       # Returns the storage account
       def get_storage_account_properties(name)
         request_path = "/services/storageservices/#{name}"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.storage_services_from_xml(response)
       end
@@ -104,7 +104,7 @@ module Azure
           Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
-          request = ManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
           request.call
         end
       end
@@ -138,7 +138,7 @@ module Azure
           Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
-          request = ManagementHttpRequest.new(:put, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
           Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
@@ -156,7 +156,7 @@ module Azure
       def delete_storage_account(name)
         Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call
       rescue Exception => e
         e.message

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -99,9 +99,9 @@ module Azure
       def create_storage_account(name, options = {})
         raise 'Name not specified' if !name || name.class != String || name.empty?
         if get_storage_account(name)
-          Loggerx.warn "Storage Account #{name} already exists. Skipped..."
+          Azure::Loggerx.warn "Storage Account #{name} already exists. Skipped..."
         else
-          Loggerx.info "Creating Storage Account #{name}."
+          Azure::Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -135,13 +135,13 @@ module Azure
       # Fails with RuntimeError if invalid options specified
       def update_storage_account(name, options = {})
         if get_storage_account name
-          Loggerx.info "Account '#{name}' exists, updating..."
+          Azure::Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
           request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
-          Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
+          Azure::Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
         end
       end
 
@@ -154,7 +154,7 @@ module Azure
       #
       # Returns:  None
       def delete_storage_account(name)
-        Loggerx.info "Deleting Storage Account #{name}."
+        Azure::Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call

--- a/lib/azure/virtual_machine_image_management/serialization.rb
+++ b/lib/azure/virtual_machine_image_management/serialization.rb
@@ -18,7 +18,8 @@ require 'azure/virtual_machine_image_management/virtual_machine_disk'
 module Azure
   module VirtualMachineImageManagement
     module Serialization
-
+      extend Azure::Core::Utility
+      
       def self.virtual_machine_images_from_xml(imageXML)
         os_images = Array.new
         virtual_machine_images = imageXML.css('Images OSImage')

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -59,7 +59,7 @@ module Azure
       #
       # Returns None
       def delete_virtual_machine_disk(disk_name)
-        Azure::Loggerx.info "Deleting Disk \"#{disk_name}\". "
+        Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -16,7 +16,7 @@ require "azure/virtual_machine_image_management/serialization"
 
 module Azure
   module VirtualMachineImageManagement
-    class VirtualMachineImageManagementService < BaseManagementService
+    class VirtualMachineImageManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -27,14 +27,14 @@ module Azure
       # Returns an array of Azure::VirtualMachineImageManagementService objects
       def list_virtual_machine_images
         request_path = "/services/images"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.virtual_machine_images_from_xml(response)
       end
  
     end
 
-    class VirtualMachineDiskManagementService < BaseManagementService
+    class VirtualMachineDiskManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -45,7 +45,7 @@ module Azure
       # Returns an array of Azure::VirtualMachineDiskManagementService objects
       def list_virtual_machine_disks
         request_path = "/services/disks"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.disks_from_xml(response)
       end
@@ -61,7 +61,7 @@ module Azure
       def delete_virtual_machine_disk(disk_name)
         Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
-        request = ManagementHttpRequest.new(:delete, path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call
       end
 

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -59,7 +59,7 @@ module Azure
       #
       # Returns None
       def delete_virtual_machine_disk(disk_name)
-        Loggerx.info "Deleting Disk \"#{disk_name}\". "
+        Azure::Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -18,6 +18,7 @@ require 'base64'
 module Azure
   module VirtualMachineManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.shutdown_virtual_machine_to_xml
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.ShutdownRoleOperation(

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -346,7 +346,7 @@ module Azure
 
       def self.add_data_disk_to_xml(lun, media_link, options)
         if options[:import] && options[:disk_name].nil?
-          Loggerx.error_with_exit "The data disk name is not valid."
+          Azure::Loggerx.error_with_exit "The data disk name is not valid."
         end
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.DataVirtualHardDisk(

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -347,7 +347,7 @@ module Azure
 
       def self.add_data_disk_to_xml(lun, media_link, options)
         if options[:import] && options[:disk_name].nil?
-          Azure::Loggerx.error_with_exit "The data disk name is not valid."
+          Loggerx.error_with_exit "The data disk name is not valid."
         end
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.DataVirtualHardDisk(

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -17,7 +17,7 @@ include Azure::VirtualMachineImageManagement
 
 module Azure
   module VirtualMachineManagement
-    class VirtualMachineManagementService < BaseManagementService
+    class VirtualMachineManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -34,7 +34,7 @@ module Azure
         end
         cloud_service_names.each do |cloud_service_name|
           request_path = "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
-          request = ManagementHttpRequest.new(:get, request_path)
+          request = BaseManagement::ManagementHttpRequest.new(:get, request_path)
           request.warn = true
           response = request.call
           roles << Serialization.virtual_machines_from_xml(response, cloud_service_name)
@@ -139,7 +139,7 @@ module Azure
         Loggerx.error 'Cloud service name is required for adding role.' unless options[:cloud_service_name]
         Loggerx.error 'Storage account name is required for adding role.' unless options[:storage_account_name]
         Loggerx.info 'Deployment in progress...'
-        request = ManagementHttpRequest.new(:post, path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
         request.call
         get_virtual_machine(params[:vm_name], options[:cloud_service_name])
       rescue Exception => e
@@ -207,7 +207,7 @@ module Azure
             path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
             body = Serialization.shutdown_virtual_machine_to_xml
             Loggerx.info "Shutting down virtual machine \"#{vm.vm_name}\" ..."
-            request = ManagementHttpRequest.new(:post, path, body)
+            request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
             request.call
           else
             Loggerx.error 'Cannot perform the shutdown operation on a stopped deployment.'
@@ -236,7 +236,7 @@ module Azure
             path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
             body = Serialization.start_virtual_machine_to_xml
             Loggerx.info "Starting virtual machine \"#{vm.vm_name}\" ..."
-            request = ManagementHttpRequest.new(:post, path, body)
+            request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
             request.call
           end
         else
@@ -260,7 +260,7 @@ module Azure
           path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
           body = Serialization.restart_virtual_machine_to_xml
           Loggerx.info "Restarting virtual machine \"#{vm.vm_name}\" ..."
-          request = ManagementHttpRequest.new(:post, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
           request.call
         else
           Loggerx.error "Cannot find virtual machine \"#{vm_name}\" under cloud service \"#{cloud_service_name}\"."
@@ -321,7 +321,7 @@ module Azure
           end
           endpoints += input_endpoints
           body = Serialization.update_role_to_xml(endpoints, vm)
-          request = ManagementHttpRequest.new(:put, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, path, body)
           Loggerx.info "Updating endpoints of virtual machine #{vm.vm_name} ..."
           request.call
         else
@@ -347,7 +347,7 @@ module Azure
           endpoints = vm.tcp_endpoints + vm.udp_endpoints
           endpoints.delete_if { |ep| endpoint_name.downcase == ep[:name].downcase }
           body = Serialization.update_role_to_xml(endpoints, vm)
-          request = ManagementHttpRequest.new(:put, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, path, body)
           Loggerx.info "Deleting virtual machine endpoint #{endpoint_name} ..."
           request.call
         else
@@ -387,7 +387,7 @@ module Azure
           path = "/services/hostedservices/#{cloud_service_name}/deployments/#{vm.deployment_name}/roles/#{vm_name}/DataDisks"
           body = Serialization.add_data_disk_to_xml(lun, vm.media_link, options)
           Loggerx.info "Adding data disk to virtual machine #{vm_name} ..."
-          request = ManagementHttpRequest.new(:post, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
           request.call
         else
           Loggerx.error "Cannot find virtual machine \"#{vm_name}\" under cloud service \"#{cloud_service_name}\"."

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -18,6 +18,8 @@ include Azure::VirtualMachineImageManagement
 module Azure
   module VirtualMachineManagement
     class VirtualMachineManagementService < BaseManagement::BaseManagementService
+      include  Azure::Core::Utility
+
       def initialize
         super()
       end

--- a/lib/azure/virtual_network_management/serialization.rb
+++ b/lib/azure/virtual_network_management/serialization.rb
@@ -17,6 +17,7 @@ require 'azure/virtual_network_management/virtual_network'
 module Azure
   module VirtualNetworkManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.virtual_network_from_xml(network_xml)
         virtual_networks = []
         virtual_network_services_xml = network_xml.css(

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -17,7 +17,7 @@ require 'azure/virtual_network_management/serialization'
 module Azure
   module VirtualNetworkManagement
     # VirtualNetworkManagementService
-    class VirtualNetworkManagementService < BaseManagementService
+    class VirtualNetworkManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -31,7 +31,7 @@ module Azure
       # Azure::VirtualNetworkServiceManagement::VirtualNetwork objects
       def list_virtual_networks
         request_path = '/services/networking/virtualnetwork'
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.virtual_network_from_xml(response)
       end
@@ -84,7 +84,7 @@ module Azure
                                                     affinity_group,
                                                     address_space,
                                                     options)
-        request = ManagementHttpRequest.new(:put, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
         Loggerx.info "Creating virtual network #{vnet}."
         request.call
@@ -99,7 +99,7 @@ module Azure
         else
           body = File.read(file)
         end
-        request = ManagementHttpRequest.new(:put, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
         Loggerx.info 'Creating virtual network.'
         request.call

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -86,7 +86,7 @@ module Azure
                                                     options)
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Azure::Loggerx.info "Creating virtual network #{vnet}."
+        Loggerx.info "Creating virtual network #{vnet}."
         request.call
       end
 
@@ -101,7 +101,7 @@ module Azure
         end
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Azure::Loggerx.info 'Creating virtual network.'
+        Loggerx.info 'Creating virtual network.'
         request.call
       end
     end

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -86,7 +86,7 @@ module Azure
                                                     options)
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Loggerx.info "Creating virtual network #{vnet}."
+        Azure::Loggerx.info "Creating virtual network #{vnet}."
         request.call
       end
 
@@ -101,7 +101,7 @@ module Azure
         end
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Loggerx.info 'Creating virtual network.'
+        Azure::Loggerx.info 'Creating virtual network.'
         request.call
       end
     end

--- a/test/integration/affinity_group/Affinity_test.rb
+++ b/test/integration/affinity_group/Affinity_test.rb
@@ -24,7 +24,7 @@ describe Azure::BaseManagementService do
     let(:options) { { description: 'Some Description' } }
 
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'get affinity group properties for an existing group' do

--- a/test/integration/affinity_group/Create_Affinity_test.rb
+++ b/test/integration/affinity_group/Create_Affinity_test.rb
@@ -21,7 +21,7 @@ describe Azure::BaseManagementService do
   let(:location) { WindowsImageLocation }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   let(:label) { 'Label Name' }

--- a/test/integration/affinity_group/Delete_Affinity_test.rb
+++ b/test/integration/affinity_group/Delete_Affinity_test.rb
@@ -17,7 +17,7 @@ require 'integration/test_helper'
 describe Azure::BaseManagementService do
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   subject { Azure::BaseManagementService.new }

--- a/test/integration/affinity_group/List_Affinity_test.rb
+++ b/test/integration/affinity_group/List_Affinity_test.rb
@@ -20,7 +20,7 @@ describe Azure::BaseManagementService do
   let(:affinity_group_name) { AffinityGroupNameHelper.name }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     subject.create_affinity_group(affinity_group_name,
                                   WindowsImageLocation,
                                   'Label Name')

--- a/test/integration/affinity_group/Update_Affinity_test.rb
+++ b/test/integration/affinity_group/Update_Affinity_test.rb
@@ -23,7 +23,7 @@ describe Azure::BaseManagementService do
   )
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   subject { Azure::BaseManagementService.new }

--- a/test/integration/database/create_sql_server_firewall_test.rb
+++ b/test/integration/database/create_sql_server_firewall_test.rb
@@ -23,7 +23,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#set_sql_server_firewall_rule" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     after {

--- a/test/integration/database/create_sql_server_test.rb
+++ b/test/integration/database/create_sql_server_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#create_server" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     it "should be able to create a new sql database server." do

--- a/test/integration/database/delete_sql_server_firewall_test.rb
+++ b/test/integration/database/delete_sql_server_firewall_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   subject { Azure::SqlDatabaseManagementService.new }
 
   before {
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     subject.set_sql_server_firewall_rule(sql_server.name, "rule1")
     ip_range = {:start_ip_address => "10.20.30.0", :end_ip_address => "10.20.30.255"}
     subject.set_sql_server_firewall_rule(sql_server.name, "rule2", ip_range)

--- a/test/integration/database/delete_sql_server_test.rb
+++ b/test/integration/database/delete_sql_server_test.rb
@@ -17,7 +17,7 @@ require "integration/test_helper"
 describe Azure::SqlDatabaseManagementService do
 
   before {
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   subject { Azure::SqlDatabaseManagementService.new }

--- a/test/integration/database/list_sql_server_firewall_test.rb
+++ b/test/integration/database/list_sql_server_firewall_test.rb
@@ -22,7 +22,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#list_sql_server_firewall_rules" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       ip_range = {:start_ip_address => "10.20.30.0", :end_ip_address => "10.20.30.255"}
       subject.set_sql_server_firewall_rule(sql_server.name, "rule1", ip_range)
       subject.set_sql_server_firewall_rule(sql_server.name, "rule2")

--- a/test/integration/database/list_sql_servers_test.rb
+++ b/test/integration/database/list_sql_servers_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#list_servers" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     it "returns a list of SQL databse servers" do

--- a/test/integration/database/reset_password_sql_server_test.rb
+++ b/test/integration/database/reset_password_sql_server_test.rb
@@ -23,7 +23,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#reset_password" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     after {

--- a/test/integration/storage_management/storage_management_test.rb
+++ b/test/integration/storage_management/storage_management_test.rb
@@ -38,7 +38,7 @@ describe Azure::StorageManagementService do
   let(:options) { { description: 'sample description' } }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   it 'list storage accounts' do

--- a/test/integration/vm/VM_Create_test.rb
+++ b/test/integration/vm/VM_Create_test.rb
@@ -62,7 +62,7 @@ describe Azure::VirtualMachineManagementService do
   end
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   describe '#deployment' do

--- a/test/integration/vm/VM_Delete_test.rb
+++ b/test/integration/vm/VM_Delete_test.rb
@@ -22,7 +22,7 @@ describe Azure::VirtualMachineManagementService do
   let(:csn) { names.last }
   let(:username) { 'admin' }
   before do
-    Loggerx.expects(:puts).at_least_once.returns(nil)
+    Azure::Loggerx.expects(:puts).at_least_once.returns(nil)
     params = {
       vm_name: virtual_machine_name,
       vm_user: 'user',

--- a/test/integration/vm/VM_Operations_test.rb
+++ b/test/integration/vm/VM_Operations_test.rb
@@ -20,7 +20,7 @@ describe Azure::VirtualMachineManagementService do
   subject { Azure::VirtualMachineManagementService.new }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     params = {
       vm_name: vm_name,
       vm_user: 'user',

--- a/test/integration/vnet/Virtual_Network_Create_test.rb
+++ b/test/integration/vnet/Virtual_Network_Create_test.rb
@@ -32,7 +32,7 @@ describe Azure::VirtualNetworkManagement::VirtualNetwork do
   subject { Azure::VirtualNetworkManagementService.new }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
 
     affinity_group_service = Azure::BaseManagementService.new
     affinity_group_service.create_affinity_group(in_affinity_name,

--- a/test/integration/vnet/Virtual_Network_list_test.rb
+++ b/test/integration/vnet/Virtual_Network_list_test.rb
@@ -23,7 +23,7 @@ describe Azure::VirtualNetworkManagement::VirtualNetwork do
   let(:vnet_name) { 'vnet-integration-test' }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     affinity_group_service = Azure::BaseManagementService.new
     affinity_group_service.create_affinity_group(affinity_group_name,
                                                  location,

--- a/test/unit/affinity_group/affinity_group_test.rb
+++ b/test/unit/affinity_group/affinity_group_test.rb
@@ -23,7 +23,7 @@ describe Azure::BaseManagementService do
   let(:response_xml) { nil }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
   end
 

--- a/test/unit/affinity_group/affinity_group_test.rb
+++ b/test/unit/affinity_group/affinity_group_test.rb
@@ -33,7 +33,7 @@ describe Azure::BaseManagementService do
     let(:method) { :get }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method,
                                              request_path,
                                              nil).returns(mock_request)
     end
@@ -92,7 +92,7 @@ describe Azure::BaseManagementService do
     let(:location_response_body) { Nokogiri::XML location_response.body }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method,
                                              request_path,
                                              anything).returns(mock_request)
       mock_request.expects(:call).returns(
@@ -100,13 +100,13 @@ describe Azure::BaseManagementService do
       ).at_least(0)
       mock_request = mock
 
-      ManagementHttpRequest.stubs(:new).with(:get,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:get,
                                              location_request_path,
                                              nil).returns(mock_request)
       mock_request.expects(:call).returns(location_response_body).at_least(0)
       mock_request = mock
 
-      ManagementHttpRequest.stubs(:new).with(:get,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:get,
                                              request_path,
                                              nil).returns(mock_request)
       mock_request.expects(:call).returns(
@@ -146,7 +146,7 @@ describe Azure::BaseManagementService do
       Azure::BaseManagementService.any_instance.stubs(
         :affinity_group
       ).returns(true)
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         :get,
         request_path,
         nil

--- a/test/unit/base_management/location_test.rb
+++ b/test/unit/base_management/location_test.rb
@@ -33,7 +33,7 @@ describe Azure::BaseManagement::Location do
     let(:response_body) { Nokogiri::XML response.body }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 

--- a/test/unit/cloud_service_management/cloud_service_management_service_test.rb
+++ b/test/unit/cloud_service_management/cloud_service_management_service_test.rb
@@ -34,7 +34,7 @@ describe Azure::CloudServiceManagementService do
 
   describe "#list_cloud_services" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
   
@@ -57,7 +57,7 @@ describe Azure::CloudServiceManagementService do
   
   describe "#get_cloud_service" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
   
@@ -79,14 +79,14 @@ describe Azure::CloudServiceManagementService do
   describe "#create_cloud_service" do
   
     it "Create cloud service return message if cloud service exists of given name." do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       msg = subject.create_cloud_service 'cloud-service-1'
       assert_match(/^Cloud service cloud-service-1 already exists*/, msg)
     end
 
     it "Create cloud service if cloud service doesn't exists of given name." do
       Azure::CloudServiceManagementService.any_instance.stubs(:get_cloud_service).with('cloud-service-3').returns(false)
-      ManagementHttpRequest.any_instance.expects(:call).returns nil
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns nil
       subject.create_cloud_service 'cloud-service-3'
     end
 

--- a/test/unit/cloud_service_management/cloud_service_management_service_test.rb
+++ b/test/unit/cloud_service_management/cloud_service_management_service_test.rb
@@ -29,7 +29,7 @@ describe Azure::CloudServiceManagementService do
   let(:response_body) { Nokogiri::XML response.body }
 
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   describe "#list_cloud_services" do

--- a/test/unit/database/sql_database_server_service_test.rb
+++ b/test/unit/database/sql_database_server_service_test.rb
@@ -24,7 +24,7 @@ describe 'Azure::SqlDatabaseManagementService' do
 
   describe 'SQL Server authentication Endpoint' do
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request.stubs(:headers).returns(response_headers)
       mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
       Azure.config.sql_database_authentication_mode = :sql_server
@@ -156,7 +156,7 @@ describe 'Azure::SqlDatabaseManagementService' do
 
   describe 'Management Certificate authentication Endpoint' do
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request.stubs(:headers).returns(response_headers)
       mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
       Azure.config.sql_database_authentication_mode = :management_certificate

--- a/test/unit/database/sql_database_server_service_test.rb
+++ b/test/unit/database/sql_database_server_service_test.rb
@@ -36,7 +36,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:request_path) { '/servers' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -94,7 +94,7 @@ describe 'Azure::SqlDatabaseManagementService' do
           :list_servers
         ).returns([sql_server])
 
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -122,7 +122,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:location) { 'West US' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           anything
@@ -168,7 +168,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:request_path) { '/servers' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -226,7 +226,7 @@ describe 'Azure::SqlDatabaseManagementService' do
           :list_servers
         ).returns([sql_server])
 
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -254,7 +254,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:location) { 'West US' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           anything

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -28,7 +28,7 @@ describe Azure::StorageManagementService do
   }
   let(:response_body) {Nokogiri::XML response.body}
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   describe "#list_storage_accounts" do

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -33,7 +33,7 @@ describe Azure::StorageManagementService do
 
   describe "#list_storage_accounts" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 
@@ -56,7 +56,7 @@ describe Azure::StorageManagementService do
 
   describe "#get_storage_account" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 
@@ -105,14 +105,14 @@ describe Azure::StorageManagementService do
     end
 
     it "Create storage account return message if storage account exists of given name." do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       msg = subject.create_storage_account 'storage1'
       assert_match(/^Storage Account storage1 already exist.*/, msg)
     end
 
     it "Create storage account if storage account doesn't exists of given name." do
       Azure::StorageManagementService.any_instance.stubs(:get_storage_account).with('storage3').returns(false)
-      ManagementHttpRequest.any_instance.expects(:call).returns nil
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns nil
       subject.create_storage_account 'storage3'
     end
 
@@ -138,7 +138,7 @@ describe Azure::StorageManagementService do
     }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
 
       Azure::StorageManagement::Serialization.stubs(:update_storage_account).returns(update_storage_account_req)
@@ -175,12 +175,12 @@ describe Azure::StorageManagementService do
     end
 
     it "updates the specified account" do
-      ManagementHttpRequest.stubs(:new).with(:put, "#{request_path}/storage2", update_storage_account_req).returns(update_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:put, "#{request_path}/storage2", update_storage_account_req).returns(update_request)
       update_request.expects(:call).returns('')
 
       subject.update_storage_account 'storage2', options
 
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(updated_storage_account_mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(updated_storage_account_mock_request)
       updated_storage_account_mock_request.expects(:call).returns(updated_storage_account_response_body)
 
       accounts = subject.list_storage_accounts
@@ -216,7 +216,7 @@ describe Azure::StorageManagementService do
     }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         :get, request_path, nil
       ).returns(get_account_mock_request)
       get_account_mock_request.expects(:call).returns(

--- a/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
+++ b/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
@@ -36,7 +36,7 @@ describe Azure::VirtualMachineImageManagementService do
   describe "#list_virtual_machine_images" do
     
     before {
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         request_path,
         nil

--- a/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
+++ b/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
@@ -30,7 +30,7 @@ describe Azure::VirtualMachineImageManagementService do
   let(:response_body) { Nokogiri::XML response.body }
 
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
   
   describe "#list_virtual_machine_images" do

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -165,7 +165,7 @@ describe Azure::VirtualMachineManagement::Serialization do
     let(:media_link) { 'https://sta.blob.managment.core.net/vhds/1234.vhd' }
     let(:lun) { 5 }
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'returns an xml for newly created data disk' do

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -15,6 +15,8 @@
 require 'test_helper'
 
 describe Azure::VirtualMachineManagement::Serialization do
+  include Azure::Core::Utility
+  
   subject { Azure::VirtualMachineManagement::Serialization }
 
   let(:vm_xml) { Nokogiri::XML(Fixtures['virtual_machine']) }

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -22,7 +22,7 @@ describe Azure::VirtualMachineManagementService do
   end
 
   before do
-    Loggerx.stubs(:info).returns(nil)
+    Azure::Loggerx.stubs(:info).returns(nil)
   end
 
   let(:params)do
@@ -285,7 +285,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::CloudServiceManagementService.any_instance.stubs(:create_cloud_service)
       Azure::CloudServiceManagementService.any_instance.stubs(:upload_certificate)
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request = mock
       Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
@@ -415,7 +415,7 @@ describe Azure::VirtualMachineManagementService do
     before do
       Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       subject.class.send(:public, *subject.class.private_instance_methods)
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'returns os type of given virtual machine image' do

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -96,13 +96,13 @@ describe Azure::VirtualMachineManagementService do
     let(:virtual_networks_response_body) { Nokogiri::XML virtual_networks_response.body }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_cloud_service_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_cloud_service_request)
       mock_cloud_service_request.expects(:call).returns(cloud_service_response_body)
-      ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-1/deploymentslots/production').returns(mock_virtual_machine_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-1/deploymentslots/production').returns(mock_virtual_machine_request)
       mock_virtual_machine_request.stubs(:warn=).returns(true).twice
-      ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-2/deploymentslots/production').returns(mock_virtual_machine_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-2/deploymentslots/production').returns(mock_virtual_machine_request)
       mock_virtual_machine_request.expects(:call).twice.returns(virtual_machine_response_body).returns(Nokogiri::XML  deployment_error_response.body)
-      ManagementHttpRequest.stubs(:new).with(method, '/services/networking/virtualnetwork', nil).returns(mock_virtual_network_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/networking/virtualnetwork', nil).returns(mock_virtual_network_request)
     end
 
     it 'assembles a URI for the request' do
@@ -198,14 +198,14 @@ describe Azure::VirtualMachineManagementService do
     end
 
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         images_request_path,
         nil
       ).returns(mock_request)
       mock_request.expects(:call).returns(os_response_body)
       mock_request = mock
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         location_request_path,
         nil
@@ -215,7 +215,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::CloudServiceManagementService.any_instance.stubs(:upload_certificate)
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
       mock_request = mock
-      ManagementHttpRequest.expects(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
         anything,
         anything
@@ -269,14 +269,14 @@ describe Azure::VirtualMachineManagementService do
     end
 
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         images_request_path,
         nil
       ).returns(mock_request)
       mock_request.expects(:call).returns(os_response_body)
       mock_request = mock
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         location_request_path,
         nil
@@ -287,7 +287,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
       Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request = mock
-      ManagementHttpRequest.expects(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
         anything,
         anything
@@ -413,7 +413,7 @@ describe Azure::VirtualMachineManagementService do
     let(:response_body) { Nokogiri::XML response.body }
 
     before do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       subject.class.send(:public, *subject.class.private_instance_methods)
       Loggerx.expects(:puts).returns(nil).at_least(0)
     end

--- a/test/unit/vnet/serialization_test.rb
+++ b/test/unit/vnet/serialization_test.rb
@@ -93,7 +93,7 @@ describe Azure::VirtualNetworkManagement::Serialization do
 
   describe '#virtual_network_to_xml' do
     before do
-      ManagementHttpRequest.any_instance.expects(
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(
         :call
       ).returns(virtual_networks_xml)
     end

--- a/test/unit/vnet/virtual_network_management_service_test.rb
+++ b/test/unit/vnet/virtual_network_management_service_test.rb
@@ -56,7 +56,7 @@ describe Azure::VirtualNetworkManagementService do
 
   describe '#list_virtual_networks' do
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         getmethod,
         list_networks_path,
         nil


### PR DESCRIPTION
I am using the Azure gem in a project and had some wired problems defining a `Location` class. After some investigation I found out that the class clashes with the Azure::BaseManagement::Location class. This is because of the line `include Azure::BaseManagement` in `lib/azure/base_management/base_management_service.rb`. This is really bad as it messes with the root namespace. I removed the `include` and fixed all references. All tests are passing. I did the same with the `Loggerx` and the include of the core utils.
<!---@tfsbridge:{"tfsId":2287004}-->