### PR TITLE
Bug fix for a subscription with single storage account

### DIFF
--- a/lib/azure/storage_management/serialization.rb
+++ b/lib/azure/storage_management/serialization.rb
@@ -107,12 +107,6 @@ module Azure
           storage_accounts << storage_account
         end
 
-        # returns the first storage account if only one found
-        # This will be the case when calling the get_storage_account_properties
-        # API or if only one storage account exists for the subscription
-        return storage_accounts.first if storage_accounts.size == 1
-
-        # returns all the storage accounts, if more than 1 found
         storage_accounts.compact
       end
 

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -67,7 +67,7 @@ module Azure
         request_path = "/services/storageservices/#{name}"
         request = ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
-        Serialization.storage_services_from_xml(response)
+        Serialization.storage_services_from_xml(response).first
       end
 
       # Public: Create a new storage account in Windows Azure.

--- a/test/fixtures/list_storage_account_single.xml
+++ b/test/fixtures/list_storage_account_single.xml
@@ -1,0 +1,25 @@
+
+<?xml version="1.0"?>
+<StorageServices xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <StorageService>
+    <Url>https://management.core.windows.net/268a3762-abcd-4cd3-a4ea-80e84bddff87/services/storageservices/storage1</Url>
+    <ServiceName>storage1</ServiceName>
+    <StorageServiceProperties>
+      <Description i:nil="true"/>
+      <Location>West US</Location>
+      <Label>c3VzZQ==</Label>
+      <Status>Created</Status>
+      <Endpoints>
+        <Endpoint>http://storage1.blob.core.windows.net/</Endpoint>
+        <Endpoint>http://storage1.queue.core.windows.net/</Endpoint>
+        <Endpoint>http://storage1.table.core.windows.net/</Endpoint>
+      </Endpoints>
+      <GeoReplicationEnabled>true</GeoReplicationEnabled>
+      <GeoPrimaryRegion>West US</GeoPrimaryRegion>
+      <StatusOfPrimary/>
+      <GeoSecondaryRegion>East US</GeoSecondaryRegion>
+      <StatusOfSecondary/>
+    </StorageServiceProperties>
+    <ExtendedProperties/>
+  </StorageService>
+</StorageServices>

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -19,14 +19,25 @@ describe Azure::StorageManagementService do
   subject { Azure::StorageManagementService.new }
   let(:request_path) {'/services/storageservices'}
   let(:storage_accounts_xml) { Fixtures["list_storage_accounts"] }
+  let(:one_storage_account_xml) { Fixtures['list_storage_account_single']}
   let(:method) { :get }
   let(:mock_request){ mock() }
+
   let(:response) {
     response = mock()
     response.stubs(:body).returns(storage_accounts_xml)
     response
   }
+
+  let(:single_response) {
+    single_response = mock()
+    single_response.stubs(:body).returns(one_storage_account_xml)
+    single_response
+  }
+
   let(:response_body) {Nokogiri::XML response.body}
+  let(:single_response_body) { Nokogiri::XML single_response.body }
+
   before{
     Loggerx.expects(:puts).returns(nil).at_least(0)
   }
@@ -51,6 +62,23 @@ describe Azure::StorageManagementService do
       results.must_be_kind_of Array
       results.length.must_equal 2
       results.first.must_be_kind_of Azure::StorageManagement::StorageAccount
+    end
+  end
+
+  describe "#list_storage_accounts_single" do
+    before {
+      ManagementHttpRequest.stubs(:new).with(
+        method, request_path, nil
+      ).returns(mock_request)
+      mock_request.expects(:call).returns(single_response_body)
+    }
+
+    it "returns an array even if single account exists" do
+      results = subject.list_storage_accounts
+      results.must_be_kind_of Array
+      results.length.must_equal 1
+      results.first.must_be_kind_of Azure::StorageManagement::StorageAccount
+      results.first.name.must_equal 'storage1'
     end
   end
 


### PR DESCRIPTION
`get_storage_account` was failing for a subscription with a single storage account because the `list_storage_account` method was returning a `StorageAccount` instance instead of an `Array` of `StorageAccount` objects.
