### PR TITLE
Support for multiple configurations and a few other items

### DIFF
--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -29,11 +29,12 @@ Loggerx = Azure::Core::Logger
 module Azure
   module BaseManagement
     class BaseManagementService
-      def initialize
+      def initialize(config=nil)
+        @config = config || Azure.config unless @config
         validate_configuration
-        cert_file = File.read(Azure.config.management_certificate)
+        cert_file = File.read(@config.management_certificate)
         begin
-          if Azure.config.management_certificate =~ /(pem)$/
+          if @config.management_certificate =~ /(pem)$/
             certificate_key = OpenSSL::X509::Certificate.new(cert_file)
             private_key = OpenSSL::PKey::RSA.new(cert_file)
           else
@@ -48,26 +49,25 @@ module Azure
           raise "Management certificate not valid. Error: #{e.message}"
         end
 
-        Azure.configure do |config|
-          config.http_certificate_key = certificate_key
-          config.http_private_key = private_key
-        end
+        
+        @config.http_certificate_key = certificate_key
+        @config.http_private_key = private_key
       end
 
       def validate_configuration
-        subs_id = Azure.config.subscription_id
+        subs_id = @config.subscription_id
         error_message = 'Subscription ID not valid.'
         raise error_message if subs_id.nil? || subs_id.empty?
 
-        m_ep = Azure.config.management_endpoint
+        m_ep = @config.management_endpoint
         error_message = 'Management endpoint not valid.'
         raise error_message if m_ep.nil? || m_ep.empty?
 
-        m_cert = Azure.config.management_certificate
+        m_cert = @config.management_certificate
         error_message = "Could not read from file '#{m_cert}'."
         raise error_message unless test('r', m_cert)
 
-        m_cert = Azure.config.management_certificate
+        m_cert = @config.management_certificate
         error_message = 'Management certificate expects a .pem or .pfx file.'
         raise error_message unless m_cert =~ /(pem|pfx)$/
       end

--- a/lib/azure/base_management/management_http_request.rb
+++ b/lib/azure/base_management/management_http_request.rb
@@ -28,9 +28,11 @@ module Azure
       # method  - Symbol. The HTTP method to use (:get, :post, :put, :del, etc...)
       # path    - URI. The URI of the HTTP endpoint to query
       # body    - IO or String. The request body (optional)
+      # config  - Azure Configuration object. (optional)
       # key     - String. The request key
       # cert    - String. The request certificate
-      def initialize(method, path, body = nil)
+      def initialize(method, path, body = nil, config = nil)
+        @config = config || Azure.config unless @config
         super
         @warn = false
         content_length = body ? body.bytesize.to_s : '0'
@@ -39,9 +41,9 @@ module Azure
           'Content-Type' => 'application/xml',
           'Content-Length' => content_length
         }
-        @uri = URI.parse(Azure.config.management_endpoint + Azure.config.subscription_id + path)
-        @key = Azure.config.http_private_key
-        @cert = Azure.config.http_certificate_key
+        @uri = URI.parse(@config.management_endpoint + @config.subscription_id + path)
+        @key = @config.http_private_key
+        @cert = @config.http_certificate_key
       end
 
       # Public: Sends a request to HTTP server and returns a HttpResponse
@@ -98,7 +100,7 @@ module Azure
       #
       # Print Error or Success of Operation.
       def check_completion(request_id)
-        request_path = "/#{Azure.config.subscription_id}/operations/#{request_id}"
+        request_path = "/#{@config.subscription_id}/operations/#{request_id}"
         http = http_setup
         headers['Content-Length'] = '0'
         @method = :get

--- a/lib/azure/base_management/sql_management_http_request.rb
+++ b/lib/azure/base_management/sql_management_http_request.rb
@@ -24,11 +24,13 @@ module Azure
       # method  - Symbol. The HTTP method to use (:get, :post, :put, :del, etc...)
       # path    - URI. The URI of the HTTP endpoint to query
       # body    - IO or String. The request body (optional)
-      def initialize(method, path, body = nil)
+      # config  - Azure Configuration object (optional)
+      def initialize(method, path, body = nil, config =  nil)
+        @config = config || Azure.config unless @config
         if sql_endpoint?
           super(method, path, body)
           @headers['x-ms-version'] = '1.0'
-          @uri = URI.parse(Azure.config.sql_database_management_endpoint + Azure.config.subscription_id + path)
+          @uri = URI.parse(@config.sql_database_management_endpoint + @config.subscription_id + path)
         else
           path = "/services/sqlservers#{path}"
           super(method, path, body)
@@ -38,7 +40,7 @@ module Azure
       private
 
       def sql_endpoint?
-        Azure.config.sql_database_authentication_mode == :sql_server
+        @config.sql_database_authentication_mode == :sql_server
       end
     end
   end

--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -20,9 +20,10 @@ module Azure
   module Blob
     class BlobService < Service::StorageService
 
-      def initialize
+      def initialize(config = nil)
+        @config = config || Azure.config unless @config
         super()
-        @host = Azure.config.storage_blob_host
+        @host = @config.storage_blob_host
       end
 
       # Public: Get a list of Containers from the server

--- a/lib/azure/core/auth/shared_key.rb
+++ b/lib/azure/core/auth/shared_key.rb
@@ -29,9 +29,11 @@ module Azure
         #                global configuration.
         # access_key   - The access_key encoded in Base64. Defaults to the
         #                one in the global configuration.
-        def initialize(account_name=Azure.config.storage_account_name, access_key=Azure.config.storage_access_key)
-          @account_name = account_name
-          super(access_key)
+        # config       - Azure Configuration object.
+        def initialize(account_name=nil, access_key=nil, config=nil)
+          @config = config || Azure.config unless @config
+          @account_name = account_name || @config.storage_account_name
+          super(access_key || @config.storage_access_key)
         end
 
         # Public: The name of the strategy.

--- a/lib/azure/core/auth/signer.rb
+++ b/lib/azure/core/auth/signer.rb
@@ -29,8 +29,10 @@ module Azure
         #
         # access_key - The access_key encoded in Base64. Defaults to the one
         #              in the global configuration.
-        def initialize(access_key=Azure.config.storage_access_key)
-          @access_key = Base64.strict_decode64(access_key)
+        # config     - Azure Configuration object.
+        def initialize(access_key=nil, config = nil)
+          @config = config || Azure.config unless @config
+          @access_key = Base64.strict_decode64(access_key || @config.storage_access_key)
         end
 
         # Public: Generate an HMAC signature.

--- a/lib/azure/core/configuration.rb
+++ b/lib/azure/core/configuration.rb
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "singleton"
 
 module Azure
 
@@ -50,9 +49,18 @@ module Azure
       Configuration.instance
     end
 
-    # Singleton that keeps the configuration of the system.
+    # Azure API Configuration
     class Configuration
-      include Singleton
+      @@the_instance = nil
+ 
+      def self.instance
+        @@the_instance = self.new unless @@the_instance
+        return @@the_instance 
+      end
+
+      def self.set_instance(instance)
+        @@the_instance = instance
+      end
 
       # Public: Get/Set the Access Key for this service.
       attr_accessor :storage_access_key

--- a/lib/azure/core/signed_service.rb
+++ b/lib/azure/core/signed_service.rb
@@ -24,11 +24,12 @@ module Azure
       # Create a new instance of the SignedService
       #
       # signer        - Azure::Core::Auth::Signer. An implementation of Signer used for signing requests. (optional, Default=Azure::Core::Auth::SharedKey.new)
-      # account_name  - String. The account name (optional, Default=Azure.config.storage_account_name)  
-      def initialize(signer=Core::Auth::SharedKey.new, account_name=Azure.config.storage_account_name)
+      # account_name  - String. The account name (optional)
+      def initialize(signer=nil, account_name=nil, config=nil)
+        @config = config || Azure.config unless @config
         super()
-        @account_name = account_name
-        @signer = signer
+        @account_name = account_name || @config.storage_account_name
+        @signer = signer || Core::Auth::SharedKey.new(nil, @config)
         filters.unshift Core::Http::SignerFilter.new(signer) if signer
       end
 

--- a/lib/azure/queue/queue_service.rb
+++ b/lib/azure/queue/queue_service.rb
@@ -19,9 +19,10 @@ module Azure
   module Queue
     class QueueService < Service::StorageService
 
-      def initialize
+      def initialize(config = nil)
+        @config = config || Azure.config unless @config
         super()
-        @host = Azure.config.storage_queue_host
+        @host = @config.storage_queue_host
       end
 
       # Public: Get a list of Queues from the server

--- a/lib/azure/service/storage_service.rb
+++ b/lib/azure/service/storage_service.rb
@@ -21,9 +21,11 @@ module Azure
       # Create a new instance of the StorageService
       #
       # signer        - Azure::Core::Auth::Signer. An implementation of Signer used for signing requests. (optional, Default=Azure::Core::Auth::SharedKey.new)
-      # account_name  - String. The account name (optional, Default=Azure.config.storage_account_name)  
-      def initialize(signer=Core::Auth::SharedKey.new, account_name=Azure.config.storage_account_name)
-        super(signer, account_name)
+      # account_name  - String. The account name (optional)
+      def initialize(signer=nil, account_name=nil, config =nil)
+        @config = config || Azure.config unless @config 
+        signer = signer || Core::Auth::SharedKey.new(nil, nil, @config )
+        super(signer, account_name || @config.storage_account_name)
       end
 
 

--- a/lib/azure/service_bus/auth/wrap_service.rb
+++ b/lib/azure/service_bus/auth/wrap_service.rb
@@ -20,10 +20,11 @@ module Azure
     module Auth
       class WrapService < Azure::Core::FilteredService
 
-        def initialize(host=Azure.config.acs_host, issuer=Azure.config.sb_issuer, access_key=Azure.config.sb_access_key)
-          super(host)
-          @issuer = issuer
-          @access_key = access_key
+        def initialize(host=nil, issuer=nil, access_key=nil, config=nil)
+          @config = config || Azure.config unless @config
+          super(host || @config.acs_host)
+          @issuer = issuer || @config.sb_issuer
+          @access_key = access_key || @config.sb_access_key
         end
 
         # Gets a WRAP access token with specified parameters.

--- a/lib/azure/service_bus/service_bus_service.rb
+++ b/lib/azure/service_bus/service_bus_service.rb
@@ -25,9 +25,10 @@ module Azure
 
       DEFAULT_TIMEOUT = 60
 
-      def initialize(host=Azure.config.service_bus_host)
+      def initialize(host=nil, config=nil)
+         @config = config || Azure.config unless @config 
         super(Azure::ServiceBus::Auth::WrapSigner.new)
-          @host = host
+          @host = host || @config.service_bus_host
           
           with_filter do |req, res| 
             req.headers.delete "x-ms-date"

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -18,7 +18,8 @@ module Azure
   module SqlDatabaseManagement
     class SqlDatabaseManagementService < BaseManagementService
 
-      def initialize
+      def initialize(config = nil)
+        @config = config || Azure.config unless @config
         super()
       end
 
@@ -129,7 +130,7 @@ module Azure
           end
           request = SqlManagementHttpRequest.new(method, request_path, body)
           request.headers['x-ms-version'] = '1.0'
-          request.uri = URI.parse(Azure.config.sql_database_management_endpoint + Azure.config.subscription_id + request_path)
+          request.uri = URI.parse(@config.sql_database_management_endpoint + @config.subscription_id + request_path)
           # Management certificate authentication Endpoint throws errors for this operation. Need to re-visit
           # this once the Azure API is working.
 
@@ -189,7 +190,7 @@ module Azure
           if sql_server
             return sql_server
           else
-            error = Azure::Error::Error.new("DatabaseServerNotFound", 40647,  "Subscription #{Azure.config.subscription_id} does not have server #{server_name}.")
+            error = Azure::Error::Error.new("DatabaseServerNotFound", 40647,  "Subscription #{@config.subscription_id} does not have server #{server_name}.")
           end
         end
         raise error if error

--- a/lib/azure/storage_management/serialization.rb
+++ b/lib/azure/storage_management/serialization.rb
@@ -49,6 +49,7 @@ module Azure
         storage_account_keys.url = xml_content(storage_service_xml, 'Url')
         storage_account_keys.primary_key = xml_content(service_key_xml, 'Primary')
         storage_account_keys.secondary_key = xml_content(service_key_xml, 'Secondary')
+        return storage_account_keys
       end
 
       def self.storage_services_from_xml(storage_xml)

--- a/lib/azure/storage_management/serialization.rb
+++ b/lib/azure/storage_management/serialization.rb
@@ -41,6 +41,16 @@ module Azure
         builder.doc.to_xml
       end
 
+      def self.storage_account_keys_from_xml(storage_xml)
+        storage_xml.css('StorageService')
+        storage_service_xml = storage_xml.css('StorageService').first
+        service_key_xml = storage_service_xml.css('StorageServiceKeys').first
+        storage_account_keys = StorageAccountKeys.new
+        storage_account_keys.url = xml_content(storage_service_xml, 'Url')
+        storage_account_keys.primary_key = xml_content(service_key_xml, 'Primary')
+        storage_account_keys.secondary_key = xml_content(service_key_xml, 'Secondary')
+      end
+
       def self.storage_services_from_xml(storage_xml)
         storage_accounts = []
         storage_services_xml = storage_xml.css('StorageService')

--- a/lib/azure/storage_management/storage_account.rb
+++ b/lib/azure/storage_management/storage_account.rb
@@ -36,5 +36,12 @@ module Azure
       attr_accessor :creation_time
       attr_accessor :extended_properties
     end
+
+    # Represents Windows Azure storage account keys
+    class StorageAccountKeys
+      attr_accessor :url
+      attr_accessor :primary_key
+      attr_accessor :secondary_key
+    end
   end
 end

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -54,6 +54,20 @@ module Azure
         flag
       end
 
+      # Public: Gets the keys of the storage account specified.
+      # 
+      # ==== Attributes
+      #
+      # * +name+  - String. The name of the storage account. Required.
+      #
+      # Returns the storage account keys
+      def get_storage_account_keys(name)
+        request_path = "/services/storageservices/#{name}/keys"
+        request = ManagementHttpRequest.new(:get, request_path, nil)
+        response = request.call
+        Serialization.storage_account_keys_from_xml(response)
+      end
+
       # Public: Gets the properties of the storage account specified.
       # 
       # ==== Attributes

--- a/lib/azure/table/auth/shared_key.rb
+++ b/lib/azure/table/auth/shared_key.rb
@@ -30,9 +30,10 @@ module Azure
         #                global configuration.
         # access_key   - The access_key encoded in Base64. Defaults to the
         #                one in the global configuration.
-        def initialize(account_name=Azure.config.storage_account_name, access_key=Azure.config.storage_access_key)
-          @account_name = account_name
-          super(access_key)
+        def initialize(account_name=nil, access_key=nil, config=nil)
+          @config = config || Azure.config unless @config
+          @account_name = account_name || @config.storage_account_name 
+          super(access_key || @config.storage_access_key)
         end
 
         # Public: The name of the strategy.

--- a/lib/azure/table/table_service.rb
+++ b/lib/azure/table/table_service.rb
@@ -23,9 +23,10 @@ module Azure
   module Table
     class TableService < Azure::Service::StorageService
 
-      def initialize
+      def initialize(config=nil)
+        @config = config || Azure.config unless @config
         super(Azure::Table::Auth::SharedKey.new)
-        @host = Azure.config.storage_table_host
+        @host = @config.storage_table_host
       end
 
       # Public: Creates new table in the storage account

--- a/lib/azure/virtual_machine_image_management/serialization.rb
+++ b/lib/azure/virtual_machine_image_management/serialization.rb
@@ -28,6 +28,8 @@ module Azure
           image.name = xml_content(image_node, 'Name')
           image.category = xml_content(image_node, 'Category')
           image.locations = xml_content(image_node, 'Location')
+          image.media_link = xml_content(image_node, 'MediaLink')
+
           os_images << image
         end
         os_images

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image.rb
@@ -20,7 +20,7 @@ module Azure
         yield self if block_given?
       end
 
-      attr_accessor :os_type, :name, :category, :locations
+      attr_accessor :os_type, :name, :category, :locations, :media_link
 
     end
   end

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -48,11 +48,16 @@ module Azure
       #
       # * +name+                - String. Virtual machine name.
       # * +cloud_service_name+  - String. Cloud service name.
+      # * +ignore_case+         - Boolean. Ignore case of machine and cloud service strings.
       #
       # Returns an  Azure::VirtualMachineManagement::VirtualMachine instance.
-      def get_virtual_machine(name, cloud_service_name)
-        server = list_virtual_machines(cloud_service_name).select { |x| x.vm_name == name && x.cloud_service_name == cloud_service_name }
-        server.first
+      def get_virtual_machine(name, cloud_service_name, ignore_case=false)
+        virtual_machines = list_virtual_machines(cloud_service_name)
+        if ignore_case
+          virtual_machines.select { |x| x.vm_name.casecmp(name) == 0 && x.cloud_service_name.casecmp(cloud_service_name) == 0 }.first
+        else
+          virtual_machines.select { |x| x.vm_name == name && x.cloud_service_name == cloud_service_name }.first
+        end
       end
 
       # Public: Provisions a virtual machine based on the supplied configuration.

--- a/test/unit/core/configuration_test.rb
+++ b/test/unit/core/configuration_test.rb
@@ -1,0 +1,51 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+require "test_helper"
+require "azure/core/configuration"
+
+describe Azure::Core::Configuration do
+  subject { Azure::Core::Configuration }
+  before(:each) do
+    # Many of the Azure tests outside of this file are dependent on a single
+    # global configuration.  Save this config and restore it after we are done.
+    $azure_global_configuration = subject.instance
+    subject.set_instance(nil)
+  end
+
+  after(:each) do
+    subject.set_instance($azure_global_configuration)
+  end
+
+  describe '.set_instance' do
+    it 'sets the current Configuration instance' do
+      subject.set_instance($azure_global_configuration)
+      subject.instance.must_equal $azure_global_configuration
+    end
+  end
+
+  describe '.instance' do
+    it 'creates a fresh Configuration object when the current instance is nil' do
+      subject.instance.storage_access_key = 'foobar'
+      subject.set_instance(nil)
+      subject.instance.must_be_instance_of Azure::Core::Configuration
+      subject.instance.storage_access_key.must_equal nil 
+    end
+
+    it 'maintains an existing Configuration instance' do
+      subject.instance.storage_access_key = 'foobar'
+      subject.instance.storage_access_key.must_equal 'foobar'
+    end
+  end
+end

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -258,4 +258,50 @@ describe Azure::StorageManagementService do
       account.label.must_equal(label)
     end
   end
+
+
+  describe '#get_storage_account_keys' do
+    let(:account_name) { 'storage2' }
+    let(:label) { 'ValidLabel' }
+    let(:request_path) { "/services/storageservices/#{account_name}/keys" }
+    let(:account_keys_xml) { "<?xml version=\"1.0\"?>\n<StorageService xmlns=\"http://schemas.microsoft.com/windowsazure\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">\n  <Url>https://management.core.windows.net/01234567-89ab-cdef-0123-456789abcdef/services/storageservices/myexamplestorage1</Url>\n  <StorageServiceKeys>\n    <Primary>XrmGWqu9qpgKX5G3lf+V5Bc0nFIGjGWiWhHTdMxkA5Mb4WjJ0rDV+3USWW/6fAWCrszrkr2+JUb1c5mxQdq4nw==</Primary>\n    <Secondary>VuXywhZaNbkh//SN70yL1w6na2H1FUOvjukSOAReQ6QM4kHNY7LmQUhgENw6Tp/SBz4y65R3Y5L5c5+zqXNvVA==</Secondary>\n  </StorageServiceKeys>\n</StorageService>" } 
+    let(:mock_request) { mock() }
+    let(:mock_response) {
+      mock_response = mock()
+      mock_response.stubs(:body).returns(account_keys_xml)
+      mock_response
+    }
+    let(:response_body) {
+      Nokogiri::XML(mock_response.body)
+    }
+
+    before {
+      ManagementHttpRequest.stubs(:new).with(
+        :get, request_path, nil
+      ).returns(mock_request)
+      mock_request.expects(:call).returns(
+        response_body
+      )
+    }
+
+    it 'Returns a StorageAccountKeys object' do
+      keys = subject.get_storage_account_keys(account_name)
+      keys.must_be_instance_of(Azure::StorageManagement::StorageAccountKeys)
+    end
+
+    it 'returns the xml url' do
+      keys = subject.get_storage_account_keys(account_name)
+      keys.url.must_equal('https://management.core.windows.net/01234567-89ab-cdef-0123-456789abcdef/services/storageservices/myexamplestorage1')
+    end
+
+    it 'returns the primary key' do
+      keys = subject.get_storage_account_keys(account_name)
+      keys.primary_key.must_equal('XrmGWqu9qpgKX5G3lf+V5Bc0nFIGjGWiWhHTdMxkA5Mb4WjJ0rDV+3USWW/6fAWCrszrkr2+JUb1c5mxQdq4nw==')
+    end
+
+    it 'returns the secondary key' do
+      keys = subject.get_storage_account_keys(account_name)
+      keys.secondary_key.must_equal('VuXywhZaNbkh//SN70yL1w6na2H1FUOvjukSOAReQ6QM4kHNY7LmQUhgENw6Tp/SBz4y65R3Y5L5c5+zqXNvVA==')
+    end
+  end
 end

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -178,9 +178,22 @@ describe Azure::VirtualMachineManagementService do
       virtual_machine.must_equal nil
     end
 
-    it 'return virtual machine instance if virtual machine name and cloud server name are valid ' do
+    it 'return virtual machine instance if virtual machine name and cloud server name match exactly' do
       virtual_machine = subject.get_virtual_machine 'instance-name', 'cloud-service-1'
       virtual_machine.must_be_kind_of VirtualMachine
+    end
+
+    describe 'the virtual machine name and cloud server name are valid but do not match given a difference in character case' do
+  
+      it 'return nil if the function is not instructed to ignore case' do
+        virtual_machine = subject.get_virtual_machine 'Instance-name', 'Cloud-service-1'
+        virtual_machine.must_equal nil
+      end
+  
+      it 'return virtual machine instance if the function is instructed to ignore case' do
+        virtual_machine = subject.get_virtual_machine 'INSTANCE-NAME', 'CLOUD-SERVICE-1', true
+        virtual_machine.must_be_kind_of VirtualMachine
+      end
     end
   end
 


### PR DESCRIPTION
What:  Added support for multiple configurations.
Why:  An application needs to manage multiple accounts in parallel.  The singleton configuration design prevents this.  I've made changes to Azure::Core::Configuration and classes that rely on this object to allow for both a single global configuration and configurations that can be passed into the azure api as needed.

What:  Added the ability to retrieve keys for a storage account.
Why:  An application needs to manage storage accounts without having the keys preloaded.  The keys must be retrieved via the Azure api.

What:  Included the media_link value in retrieved virtual machine images.
Why:  An application is creating virtual machines from account images.  The media_link info associated with these images contains the storage account name.  This is needed when creating the virtual machine from the image.

What:  Added ability to ignore case when retrieving virtual machines.
Why:  The Azure cloud ignores case on virtual machine and cloud service names.  You cannot create two machines named 'onevm' and 'oneVm'.  These are considered to be equivalent names.  The retrieval of a virtual machine by name should allow for the same equivalency.
<!---@tfsbridge:{"tfsId":2287002}-->