### PR TITLE
changed virtual machine management and image management to use vmimages ...

### DIFF
--- a/lib/azure/virtual_machine_image_management/serialization.rb
+++ b/lib/azure/virtual_machine_image_management/serialization.rb
@@ -28,9 +28,27 @@ module Azure
           image.name = xml_content(image_node, 'Name')
           image.category = xml_content(image_node, 'Category')
           image.locations = xml_content(image_node, 'Location')
+          image.image_type = :os_image
           os_images << image
         end
         os_images
+      end
+
+      def self.virtual_machine_vmimages_from_xml(imageXML)
+        vm_images = Array.new
+        virtual_machine_vmimages = imageXML.css('VMImages VMImage')
+        virtual_machine_vmimages.each do |image_node|
+          image = VirtualMachineImage.new
+          image.name = xml_content(image_node, 'Name')
+          image.category = xml_content(image_node, 'Category')
+          image.locations = xml_content(image_node, 'Location')
+          os_disk_configuration = image_node.css('OSDiskConfiguration' )
+
+          image.os_type = xml_content(os_disk_configuration, 'OS')
+          image.image_type = :vm_image
+          vm_images << image
+        end
+        vm_images
       end
 
       def self.disks_from_xml(diskXML)

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image.rb
@@ -20,7 +20,7 @@ module Azure
         yield self if block_given?
       end
 
-      attr_accessor :os_type, :name, :category, :locations
+      attr_accessor :os_type, :name, :category, :locations, :image_type
 
     end
   end

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -29,7 +29,16 @@ module Azure
         request_path = "/services/images"
         request = ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
-        Serialization.virtual_machine_images_from_xml(response)
+        images = Serialization.virtual_machine_images_from_xml(response)
+        
+
+        request_path = "/services/vmimages"
+        request = ManagementHttpRequest.new(:get, request_path, nil)
+        response = request.call
+        #puts response
+        images += Serialization.virtual_machine_vmimages_from_xml(response)
+
+        images
       end
  
     end

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -99,6 +99,7 @@ module Azure
       # Returns Azure::VirtualMachineManagement::VirtualMachine objects of newly created instance.
       def create_virtual_machine(params, options={})
         options[:os_type] = get_os_type(params[:image])
+        options[:image_type] = get_image_type(params[:image])
         validate_deployment_params(params, options)
         options[:cloud_service_name] = generate_cloud_service_name(params[:vm_name]) unless options[:cloud_service_name]
         options[:storage_account_name] = generate_storage_account_name(params[:vm_name]) unless options[:storage_account_name] 
@@ -224,6 +225,13 @@ module Azure
         image = image_service.list_virtual_machine_images.select{|x| x.name == image_name}.first
         Loggerx.error_with_exit "The virtual machine image source is not valid." unless image
         image.os_type
+      end
+
+      def get_image_type(image_name)
+        image_service = Azure::VirtualMachineImageManagementService.new
+        image = image_service.list_virtual_machine_images.select{|x| x.name == image_name}.first
+        Loggerx.error_with_exit "The virtual machine image source is not valid." unless image
+        image.image_type
       end
 
       def generate_cloud_service_name(vm_name)


### PR DESCRIPTION
Changed virtual machine management and image management to use vmimages in addition to os images. Also added redirect code for http 307 response codes. I made these changes because we are no longer able to use the azure gem (or vagrant azure) to create new VMs from custom images that we create. I believe there may have been a change this month where user vmimages that are captured are treated differently than standard OS images. This code seems to work, but it took a lot of trial and error as I couldn't find very good documentation. I'm happy to do some further refining of this code if I were pointed to the documentation detailing the differences between /services/images and /services/vmimages, as well as the proper deployment options.
<!---@tfsbridge:{"tfsId":2286999}-->