### PR TITLE
Add option to skip auto-creating ssh_endpoint

### DIFF
--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -177,7 +177,7 @@ module Azure
         os_type = options[:os_type]
         used_ports = options[:existing_ports]
         endpoints = []
-        if os_type == 'Linux'
+        if os_type == 'Linux' && !options[:no_ssh_endpoint]
           preferred_port = '22'
           port_already_opened?(used_ports, options[:ssh_port])
           endpoints << {

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -85,6 +85,7 @@ module Azure
       # * +:ssh_private_key_file+     - String. Path of private key file.
       # * +:ssh_certificate_file+     - String. Path of certificate file.
       # * +:ssh_port+                 - Integer. Specifies the SSH port number.
+      # * +:no_ssh_endpoint+          - Boolean. True skips the creation of an endpoint for SSH
       # * +:winrm_http_port           - Integer. Specifies the WinRM HTTP port number.
       # * +:winrm_https_port          - Integer. Specifies the WinRM HTTPS port number.
       # * +:vm_size+                  - String. Specifies the size of the virtual machine instance.


### PR DESCRIPTION
The current behaviour is to create an SSH endpoint on port 22 (if
available), or on a random port if it's not, for any new Linux VM.

This commit allows this endpoint creation to be skipped, which is
useful for machines on a virtual network, which don't require
public remote access.

To skip the endpoint creation, simply add no_ssh_endpoint: true 
to the options hash for a new deployment.
