### PR TITLE
#153 - Fix bug related to passing .pfx file to management_certificate rather than .pem file

### DIFF
--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -31,14 +31,18 @@ module Azure
     class BaseManagementService
       def initialize
         validate_configuration
-        cert_file = File.read(Azure.config.management_certificate)
+        cert_file = nil
         begin
           if Azure.config.management_certificate =~ /(pem)$/
+            cert_file = File.read(Azure.config.management_certificate)
             certificate_key = OpenSSL::X509::Certificate.new(cert_file)
             private_key = OpenSSL::PKey::RSA.new(cert_file)
           else
-          # Parse pfx content
-            cert_content = OpenSSL::PKCS12.new(Base64.decode64(cert_file))
+            # Parse pfx content
+            File.open(Azure.config.management_certificate, "rb") do |f|
+                cert_file = f.read
+            end
+            cert_content = OpenSSL::PKCS12.new(cert_file)
             certificate_key = OpenSSL::X509::Certificate.new(
               cert_content.certificate.to_pem
             )


### PR DESCRIPTION
Fix issue #153.

#### Fix Details
Though no issues were encountered when using a .pem file, a parsing issue was occurring with .pfx file. The reason was that the same file reading mechanism was used on both file types, though their encoding is different(plain text for .pem and binary for .pfx). The solution simply consisted in opening the file differently based on on their extension
<!---@tfsbridge:{"tfsId":2286994}-->