### PR TITLE
#155 -  Fix issue related to timeout only setting the azure timeout but not the Net::HTTP client

### DIFF
--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -595,6 +595,7 @@ module Azure
         headers["Content-Language"] = options[:content_language] if options[:content_language]
         headers["Content-MD5"] = options[:content_md5] if options[:content_md5]
         headers["Cache-Control"] = options[:cache_control] if options[:cache_control]
+        headers["Keep-Alive"] = "timeout=#{options[:timeout]}" if options[:timeout]
 
         headers["x-ms-blob-content-type"] = options[:blob_content_type] if options[:blob_content_type]
         headers["x-ms-blob-content-encoding"] = options[:blob_content_encoding] if options[:blob_content_encoding]

--- a/lib/azure/core/http/http_request.rb
+++ b/lib/azure/core/http/http_request.rb
@@ -140,6 +140,8 @@ module Azure
             http = Net::HTTP.new(uri.host, uri.port)
           end
 
+          http.read_timeout = headers['Keep-Alive'].split("=").last.to_i unless headers.nil? || headers['Keep-Alive'].nil?
+
           if uri.scheme.downcase == 'https'
             # require 'net/https'
             http.use_ssl = true


### PR DESCRIPTION
Fix issue #155.

#### Fix Details
When specifying the timeout for method create_block_blob as follow:
```ruby
blob_options = {
    :content_type => "application/octet-stream",
    :timeout => 15*60 # 15 minutes
}
```
A "Keep-Alive: timeout=900" is added to the HTTP header. This is later extracted inside the http_request.rb to determine whether or not the Net::HTTP client should use its default timeout or replace it with the specified value(in our example, 900)
<!---@tfsbridge:{"tfsId":2286991}-->