### PR TITLE
Support get/set on storage service properties for API version 2013-08-15

### DIFF
--- a/lib/azure/service/cors.rb
+++ b/lib/azure/service/cors.rb
@@ -1,0 +1,11 @@
+module Azure
+  module Service
+    class Cors 
+      def initialize
+        yield self if block_given?
+      end
+
+      attr_accessor :cors_rules
+    end
+  end
+end

--- a/lib/azure/service/cors_rule.rb
+++ b/lib/azure/service/cors_rule.rb
@@ -1,0 +1,15 @@
+module Azure
+  module Service
+    class CorsRule
+      def initialize
+        yield self if block_given?
+      end
+
+      attr_accessor :allowed_origins
+      attr_accessor :allowed_methods
+      attr_accessor :max_age_in_seconds
+      attr_accessor :exposed_headers
+      attr_accessor :allowed_headers
+    end
+  end
+end

--- a/lib/azure/service/storage_service.rb
+++ b/lib/azure/service/storage_service.rb
@@ -35,7 +35,7 @@ module Azure
       # Returns a Hash with the service properties or nil if the operation failed
       def get_service_properties
         uri = service_properties_uri
-        response = call(:get, uri)
+        response = call(:get, uri, nil, service_properties_headers)
         Serialization.service_properties_from_xml response.body
       end
 
@@ -51,7 +51,7 @@ module Azure
         body = Serialization.service_properties_to_xml service_properties
 
         uri = service_properties_uri
-        call(:put, uri, body)
+        call(:put, uri, body, service_properties_headers)
         nil
       end
 
@@ -73,6 +73,10 @@ module Azure
         metadata.each do |key, value|
           headers["x-ms-meta-#{key}"] = value
         end
+      end
+
+      def service_properties_headers
+        {"x-ms-version" => "2013-08-15"}
       end
     end
   end

--- a/lib/azure/service/storage_service_properties.rb
+++ b/lib/azure/service/storage_service_properties.rb
@@ -14,18 +14,23 @@
 #--------------------------------------------------------------------------
 require 'azure/service/logging'
 require 'azure/service/metrics'
+require 'azure/service/cors'
 
 module Azure
   module Service
     class StorageServiceProperties
       def initialize
         @logging = Logging.new
-        @metrics = Metrics.new
+        @hour_metrics = Metrics.new
+        @minute_metrics = Metrics.new
+        @cors = Cors.new
         yield self if block_given?
       end
 
       attr_accessor :logging
-      attr_accessor :metrics
+      attr_accessor :hour_metrics
+      attr_accessor :minute_metrics
+      attr_accessor :cors
       attr_accessor :default_service_version
     end
   end

--- a/test/fixtures/metrics.xml
+++ b/test/fixtures/metrics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<Metrics>
+<HourMetrics>
   <Version>1.0</Version>
   <Enabled>true</Enabled>
   <IncludeAPIs>false</IncludeAPIs>
@@ -7,4 +7,4 @@
     <Enabled>true</Enabled>
     <Days>7</Days>
   </RetentionPolicy>
-</Metrics>
+</HourMetrics>

--- a/test/fixtures/storage_service_properties.xml
+++ b/test/fixtures/storage_service_properties.xml
@@ -10,7 +10,7 @@
       <Days>7</Days>
     </RetentionPolicy>
   </Logging>
-  <Metrics>
+  <HourMetrics>
     <Version>1.0</Version>
     <Enabled>true</Enabled>
     <IncludeAPIs>false</IncludeAPIs>
@@ -18,6 +18,37 @@
       <Enabled>true</Enabled>
       <Days>7</Days>
     </RetentionPolicy>
-  </Metrics>
-  <DefaultServiceVersion>2011-08-18</DefaultServiceVersion>
+  </HourMetrics>
+  <MinuteMetrics>
+    <Version>1.0</Version>
+    <Enabled>true</Enabled>
+    <IncludeAPIs>false</IncludeAPIs>
+    <RetentionPolicy>
+      <Enabled>true</Enabled>
+      <Days>7</Days>
+    </RetentionPolicy>
+  </MinuteMetrics>
+  <Cors>
+    <CorsRule>
+      <AllowedOrigins>http://www.contoso.com,http://dummy.uri</AllowedOrigins>
+      <AllowedMethods>PUT,HEAD</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-blob-content-type,x-ms-blob-content-disposition</AllowedHeaders>
+    </CorsRule>
+    <CorsRule>
+      <AllowedOrigins>*</AllowedOrigins>
+      <AllowedMethods>PUT,GET</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-blob-content-type,x-ms-blob-content-disposition</AllowedHeaders>
+    </CorsRule>
+    <CorsRule>
+      <AllowedOrigins>http://www.contoso.com</AllowedOrigins>
+      <AllowedMethods>GET</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-client-request-id</AllowedHeaders>
+    </CorsRule>
+  </Cors>
 </StorageServiceProperties>

--- a/test/unit/service/storage_service_test.rb
+++ b/test/unit/service/storage_service_test.rb
@@ -142,11 +142,12 @@ describe Azure::Service::StorageService do
     }
 
     let(:service_properties_uri) { URI.parse 'http://dummy.uri/service/properties' }
+    let(:service_properties_headers) { {"x-ms-version" => "2013-08-15"} }
 
     before do 
       Azure::Service::Serialization.stubs(:service_properties_from_xml).with(service_properties_xml).returns(service_properties)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:get, service_properties_uri).returns(response)
+      subject.stubs(:call).with(:get, service_properties_uri, nil, service_properties_headers).returns(response)
     end
 
     it "calls the service_properties_uri method to determine the correct uri" do
@@ -155,7 +156,7 @@ describe Azure::Service::StorageService do
     end
 
     it "gets the response from the HTTP API" do
-      subject.expects(:call).with(:get, service_properties_uri).returns(response)
+      subject.expects(:call).with(:get, service_properties_uri, nil, service_properties_headers).returns(response)
       subject.get_service_properties
     end
 
@@ -180,11 +181,12 @@ describe Azure::Service::StorageService do
     }
 
     let(:service_properties_uri) { URI.parse 'http://dummy.uri/service/properties' }
+    let(:service_properties_headers) { {"x-ms-version" => "2013-08-15"} }
 
     before do 
       Azure::Service::Serialization.stubs(:service_properties_to_xml).with(service_properties).returns(service_properties_xml)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml, service_properties_headers).returns(response)
     end
 
     it "calls the service_properties_uri method to determine the correct uri" do
@@ -193,7 +195,7 @@ describe Azure::Service::StorageService do
     end
 
     it "posts to the HTTP API" do
-      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml, service_properties_headers).returns(response)
       subject.set_service_properties service_properties
     end
 


### PR DESCRIPTION
Support get/set on storage service properties for version 2013-08-15 by adding serialization for new features and fixing the header version at  2013-08-15. Doesn't support any other version of the API for those methods. Breaks any dependencies on existence of Storage Service Metrics (as it switched to hour and minute). Not well tested.

This is not ready to be merged but I'm creating this pull request as a way to discuss this feature and to allow people who **really need** cors to use it.

Fixes #128

Related documentation [Set Blob Service Properties](http://msdn.microsoft.com/en-us/library/azure/hh452235.aspx)

<!---@tfsbridge:{"tfsId":2286985}-->
