### PR TITLE
Update mime-types to ~> 2.3

### DIFF
--- a/azure.gemspec
+++ b/azure.gemspec
@@ -31,7 +31,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency('nokogiri',   "~> 1.5")
-  s.add_runtime_dependency("mime-types", "~> 2.3")
+
+  if RUBY_VERSION.to_f <= 1.9
+    s.add_runtime_dependency("mime-types", "~> 1.0")
+  else
+    s.add_runtime_dependency("mime-types", "~> 2.3")
+  end
+
   s.add_runtime_dependency('json', '~> 1.8')
   s.add_runtime_dependency('uuid', '~> 2.0')
   s.add_runtime_dependency('systemu', '~> 2.6')


### PR DESCRIPTION
mime-types 2.3 resolves a number of issues we were experiencing when using azure combination with the fog gem
