### PR TITLE
Use millisecond resolution for generating a vhd resource for vm creation

### DIFF
--- a/azure.gemspec
+++ b/azure.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest", "~> 3.0")
   s.add_development_dependency('mocha', '~> 1.0')
   s.add_development_dependency('turn', '~> 0.9')
+  s.add_development_dependency('timecop', '~> 0.7')
 end

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -107,7 +107,7 @@ module Azure
             xml.AvailabilitySetName options[:availability_set_name]
             xml.Label Base64.encode64(params[:vm_name]).strip
             xml.OSVirtualHardDisk do
-              xml.MediaLink 'http://' + options[:storage_account_name] + '.blob.core.windows.net/vhds/' + (Time.now.strftime('disk_%Y_%m_%d_%H_%M')) + '.vhd'
+              xml.MediaLink 'http://' + options[:storage_account_name] + '.blob.core.windows.net/vhds/' + (Time.now.strftime('disk_%Y_%m_%d_%H_%M_%S_%L')) + '.vhd'
               xml.SourceImageName params[:image]
             end
             xml.RoleSize options[:vm_size]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@
 #--------------------------------------------------------------------------
 require "minitest/autorun"
 require "mocha/setup"
+require 'timecop'
 
 # Attempt to load turn to show formatted test results
 begin


### PR DESCRIPTION
When creating a vm via the sdk, the name of the default vhd backing that vm uses the media link with the following url: 

```
'http://' + options[:storage_account_name] + '.blob.core.windows.net/vhds/' + (Time.now.strftime('disk_%Y_%m_%d_%H_%M')) + '.vhd'
```

 [See this line of code.](https://github.com/devigned/azure-sdk-for-ruby/compare/fix/vm-creation-vhd-name?expand=1#diff-40516ac7d4584aff15e2bfb33578c3e9L110)

Due to the minute level resolution I've ran into issues bring up more than one vm within the same storage account with the same backing vhd. This cause creation of the vm to fail b/c it can't acquire a lease to the URI.

This pull request changes this to millisecond resolution, so there is significantly less chance of this occurring due to quickly spinning up VMs.
