### PR TITLE
Fix 'add_role' unit test launched without 'turn' gem.

### DIFF
--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -423,7 +423,7 @@ describe Azure::VirtualMachineManagementService do
         subject.add_role(windows_params, options)
       end
       error_msg = 'No such file or directory -'
-      assert_match(/#{error_msg}/i, exception.message)
+      assert_match(/#{error_msg}*/i, exception.message)
     end
 
     it 'throws error when wrong role size is given' do


### PR DESCRIPTION
One unit test fails when 'turn' gem is not available:

Azure::VirtualMachineManagement::VirtualMachineManagementService::#add_role#test_0003_throws error when certificate path is not invalid. [/usr/share/gems/gems/azure-0.6.4/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb:426]:
Expected /No such file or directory -/i to match "\e[31m\e[1mNo such file or directory @ rb_sysopen - f:/invalid_path/private_key\e[0m\e[0m".

Fixed by adding '*' as used in all other tests.