### PR TITLE
Fix: write support for StorageServiceProperties.default_service_version

### DIFF
--- a/lib/azure/service/serialization.rb
+++ b/lib/azure/service/serialization.rb
@@ -250,6 +250,7 @@ module Azure
         def service_properties_to_xml(properties)
           builder = Nokogiri::XML::Builder.new(:encoding => 'utf-8') do |xml|
             xml.StorageServiceProperties {
+              xml.DefaultServiceVersion(properties.default_service_version) if properties.default_service_version
               logging_to_xml(properties.logging, xml) if properties.logging
               hour_metrics_to_xml(properties.hour_metrics, xml) if properties.hour_metrics
               minute_metrics_to_xml(properties.minute_metrics, xml) if properties.minute_metrics

--- a/test/fixtures/storage_service_properties.xml
+++ b/test/fixtures/storage_service_properties.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StorageServiceProperties>
+  <DefaultServiceVersion>2011-08-18</DefaultServiceVersion>
   <Logging>
     <Version>1.0</Version>
     <Delete>true</Delete>


### PR DESCRIPTION
Seemingly just an optional field that was missed on the serializer.