### PR TITLE
BlobService: add ms-blob-content-disposition support, bump base `x-ms-version` header to `2013-08-15`

### DIFF
--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -29,25 +29,25 @@ module Azure
       #
       # ==== Attributes
       #
-      # * +options+       - Hash. Optional parameters. 
+      # * +options+       - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:prefix+       - String. Filters the results to return only containers 
+      # * +:prefix+       - String. Filters the results to return only containers
       #   whose name begins with the specified prefix. (optional)
       #
-      # * +:marker+       - String. An identifier the specifies the portion of the 
+      # * +:marker+       - String. An identifier the specifies the portion of the
       #   list to be returned. This value comes from the property
-      #   Azure::Service::EnumerationResults.continuation_token when there 
-      #   are more containers available than were returned. The 
+      #   Azure::Service::EnumerationResults.continuation_token when there
+      #   are more containers available than were returned. The
       #   marker value may then be used here to request the next set
       #   of list items. (optional)
       #
-      # * +:max_results+  - Integer. Specifies the maximum number of containers to return. 
-      #   If max_results is not specified, or is a value greater than 
-      #   5,000, the server will return up to 5,000 items. If it is set 
-      #   to a value less than or equal to zero, the server will return 
+      # * +:max_results+  - Integer. Specifies the maximum number of containers to return.
+      #   If max_results is not specified, or is a value greater than
+      #   5,000, the server will return up to 5,000 items. If it is set
+      #   to a value less than or equal to zero, the server will return
       #   status code 400 (Bad Request). (optional)
       #
       # * +:metadata+     - Boolean. Specifies whether or not to return the container metadata.
@@ -56,16 +56,16 @@ module Azure
       # * +:timeout+      - Integer. A timeout in seconds.
       #
       # NOTE: Metadata requested with the :metadata parameter must have been stored in
-      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob 
-      # service. Beginning with that version, all metadata names must adhere to the naming 
+      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob
+      # service. Beginning with that version, all metadata names must adhere to the naming
       # conventions for C# identifiers.
       #
-      # See: http://msdn.microsoft.com/en-us/library/aa664670(VS.71).aspx 
+      # See: http://msdn.microsoft.com/en-us/library/aa664670(VS.71).aspx
       #
-      # Any metadata with invalid names which were previously stored, will be returned with the 
+      # Any metadata with invalid names which were previously stored, will be returned with the
       # key "x-ms-invalid-name" in the metadata hash. This may contain multiple values and be an
       # Array (vs a String if it only contains a single value).
-      # 
+      #
       # Returns an Azure::Service::EnumerationResults
       def list_containers(options={})
         query = { }
@@ -76,19 +76,19 @@ module Azure
           query["include"] = "metadata" if options[:metadata] == true
           query["timeout"] = options[:timeout].to_s if options[:timeout]
         end
-        
+
         uri = containers_uri(query)
         response = call(:get, uri)
 
         Serialization.container_enumeration_results_from_xml(response.body)
       end
 
-      # Public: Create a new container 
+      # Public: Create a new container
       #
       # ==== Attributes
       #
       # * +name+          - String. The name of the container
-      # * +options+       - Hash. Optional parameters. 
+      # * +options+       - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -125,7 +125,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -148,7 +148,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -174,7 +174,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -195,13 +195,13 @@ module Azure
         container
       end
 
-      # Public: Gets the access control list (ACL) and any container-level access policies 
+      # Public: Gets the access control list (ACL) and any container-level access policies
       # for the container.
       #
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -234,14 +234,14 @@ module Azure
       #
       # * +name+                         - String. The name of the container
       # * +public_access_level+          - String. The container public access level
-      # * +options+                      - Hash. Optional parameters. 
+      # * +options+                      - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:signed_identifiers+          - Array. A list of Azure::Entity::SignedIdentifier instances (optional) 
+      # * +:signed_identifiers+          - Array. A list of Azure::Entity::SignedIdentifier instances (optional)
       # * +:timeout+                     - Integer. A timeout in seconds.
-      # 
+      #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179391.aspx
       #
       # Returns a tuple of (container, signed_identifiers)
@@ -278,7 +278,7 @@ module Azure
       #
       # * +name+      - String. The name of the container
       # * +metadata+  - Hash. A Hash of the metadata values
-      # * +options+   - Hash. Optional parameters. 
+      # * +options+   - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -303,54 +303,54 @@ module Azure
       #
       # ==== Attributes
       #
-      # * +name+              - String. The name of the container to list blobs for. 
-      # * +options+           - Hash. Optional parameters. 
+      # * +name+              - String. The name of the container to list blobs for.
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:prefix+           - String. Filters the results to return only blobs 
+      # * +:prefix+           - String. Filters the results to return only blobs
       #   whose name begins with the specified prefix. (optional)
-      # * +:delimiter+        - String. When the request includes this parameter, the operation 
-      #   returns a BlobPrefix element in the response body that acts as a 
-      #   placeholder for all blobs whose names begin with the same substring 
-      #   up to the appearance of the delimiter character. The delimiter may 
+      # * +:delimiter+        - String. When the request includes this parameter, the operation
+      #   returns a BlobPrefix element in the response body that acts as a
+      #   placeholder for all blobs whose names begin with the same substring
+      #   up to the appearance of the delimiter character. The delimiter may
       #   be a single character or a string.
-      # * +:marker+           - String. An identifier that specifies the portion of the 
+      # * +:marker+           - String. An identifier that specifies the portion of the
       #   list to be returned. This value comes from the property
-      #   Azure::Service::EnumerationResults.continuation_token when 
-      #   there are more blobs available than were returned. The 
+      #   Azure::Service::EnumerationResults.continuation_token when
+      #   there are more blobs available than were returned. The
       #   marker value may then be used here to request the next set
       #   of list items. (optional)
-      # * +:max_results+      - Integer. Specifies the maximum number of blobs to return. 
-      #   If max_results is not specified, or is a value greater than 
-      #   5,000, the server will return up to 5,000 items. If it is set 
-      #   to a value less than or equal to zero, the server will return 
+      # * +:max_results+      - Integer. Specifies the maximum number of blobs to return.
+      #   If max_results is not specified, or is a value greater than
+      #   5,000, the server will return up to 5,000 items. If it is set
+      #   to a value less than or equal to zero, the server will return
       #   status code 400 (Bad Request). (optional)
       # * +:metadata+         - Boolean. Specifies whether or not to return the blob metadata.
       #   (optional, Default=false)
-      # * +:snapshots+        - Boolean. Specifies that snapshots should be included in the 
-      #   enumeration. Snapshots are listed from oldest to newest in the 
+      # * +:snapshots+        - Boolean. Specifies that snapshots should be included in the
+      #   enumeration. Snapshots are listed from oldest to newest in the
       #   response. (optional, Default=false)
-      # * +:uncomittedblobs+  - Boolean. Specifies that blobs for which blocks have been uploaded, 
+      # * +:uncomittedblobs+  - Boolean. Specifies that blobs for which blocks have been uploaded,
       #   but which have not been committed using put_block_list, be included
       #   in the response. (optional, Default=false)
-      # * +:copy+             - Boolean. Specifies that metadata related to any current or previous 
-      #   copy_blob operation should be included in the response. 
+      # * +:copy+             - Boolean. Specifies that metadata related to any current or previous
+      #   copy_blob operation should be included in the response.
       #   (optional, Default=false)
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # NOTE: Metadata requested with the :metadata parameter must have been stored in
-      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob 
-      # service. Beginning with that version, all metadata names must adhere to the naming 
+      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob
+      # service. Beginning with that version, all metadata names must adhere to the naming
       # conventions for C# identifiers.
       #
       # See: http://msdn.microsoft.com/en-us/library/windowsazure/dd135734.aspx
       #
-      # Any metadata with invalid names which were previously stored, will be returned with the 
+      # Any metadata with invalid names which were previously stored, will be returned with the
       # key "x-ms-invalid-name" in the metadata hash. This may contain multiple values and be an
       # Array (vs a String if it only contains a single value).
-      # 
+      #
       # Returns an Azure::Service::EnumerationResults
       def list_blobs(name, options={})
         query = { "comp" => "list" }
@@ -376,13 +376,13 @@ module Azure
 
       # Public: Creates a new page blob. Note that calling create_page_blob to create a page
       # blob only initializes the blob. To add content to a page blob, call create_blob_pages method.
-      # 
+      #
       # ==== Attributes
       #
       # * +container+ - String. The container name.
       # * +blob+      - String. The blob name.
       # * +length+    - Integer. Specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.
-      # * +options+   - Hash. Optional parameters. 
+      # * +options+   - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -418,7 +418,7 @@ module Azure
         # ensure content-length is 0 and x-ms-blob-content-length is the blob length
         headers["Content-Length"] = 0.to_s
         headers["x-ms-blob-content-length"] = length.to_s
-        
+
         # set x-ms-sequence-number from options (or default to 0)
         headers["x-ms-sequence-number"] = (options[:sequence_number] || 0).to_s
 
@@ -468,7 +468,7 @@ module Azure
       # * +:if_match+               - An ETag value. Specify an ETag value for this conditional header to write the page only if the blob's ETag value matches the value specified. If the values do not match, the Blob service returns status code 412 (Precondition Failed).
       # * +:if_none_match+          - An ETag value. Specify an ETag value for this conditional header to write the page only if the blob's ETag value does not match the value specified. If the values are identical, the Blob service returns status code 412 (Precondition Failed).
       # * +:timeout+                - Integer. A timeout in seconds.
-      # 
+      #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
       #
       # Returns Blob
@@ -511,7 +511,7 @@ module Azure
       # * +blob+         - String. Name of blob.
       # * +start_range+  - Integer. Position of first byte of first page.
       # * +end_range+    - Integer. Position of last byte of of last page.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -543,7 +543,7 @@ module Azure
       end
 
       # Public: Creates a new block blob or updates the content of an existing block blob.
-      # 
+      #
       # Updating an existing block blob overwrites any existing metadata on the blob
       # Partial updates are not supported with create_block_blob the content of the
       # existing blob is overwritten with the content of the new blob. To perform a
@@ -557,23 +557,24 @@ module Azure
       # * +container+   - String. The container name.
       # * +blob+        - String. The blob name.
       # * +content+     - IO or String. The content of the blob.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:content_type+          - String. Content type for the request. Will be saved with blob unless alternate value is provided in blob_content_type.
-      # * +:content_encoding+      - String. Content encoding for the request. Will be saved with blob unless alternate value is provided in blob_content_encoding.
-      # * +:content_language+      - String. Content language for the request. Will be saved with blob unless alternate value is provided in blob_content_language.
-      # * +:content_md5+           - String. Content MD5 for the request. Will be saved with blob unless alternate value is provided in blob_content_md5.
-      # * +:cache_control+         - String. Cache control for the request. Will be saved with blob unless alternate value is provided in blob_cache_control.
-      # * +:blob_content_type+     - String. Content type for the blob. Will be saved with blob.
-      # * +:blob_content_encoding+ - String. Content encoding for the blob. Will be saved with blob.
-      # * +:blob_content_language+ - String. Content language for the blob. Will be saved with blob.
-      # * +:blob_content_md5+      - String. Content MD5 for the blob. Will be saved with blob.
-      # * +:blob_cache_control+    - String. Cache control for the blob. Will be saved with blob.
-      # * +:metadata+              - Hash. Custom metadata values to store with the blob.
-      # * +:timeout+               - Integer. A timeout in seconds.
+      # * +:content_type+             - String. Content type for the request. Will be saved with blob unless alternate value is provided in blob_content_type.
+      # * +:content_encoding+         - String. Content encoding for the request. Will be saved with blob unless alternate value is provided in blob_content_encoding.
+      # * +:content_language+         - String. Content language for the request. Will be saved with blob unless alternate value is provided in blob_content_language.
+      # * +:content_md5+              - String. Content MD5 for the request. Will be saved with blob unless alternate value is provided in blob_content_md5.
+      # * +:cache_control+            - String. Cache control for the request. Will be saved with blob unless alternate value is provided in blob_cache_control.
+      # * +:blob_content_type+        - String. Content type for the blob. Will be saved with blob.
+      # * +:blob_content_encoding+    - String. Content encoding for the blob. Will be saved with blob.
+      # * +:blob_content_language+    - String. Content language for the blob. Will be saved with blob.
+      # * +:blob_content_md5+         - String. Content MD5 for the blob. Will be saved with blob.
+      # * +:blob_cache_control+       - String. Cache control for the blob. Will be saved with blob.
+      # * +:blob_content_disposition+ - String. Content disposition for the blob. Will be saved with blob.
+      # * +:metadata+                 - Hash. Custom metadata values to store with the blob.
+      # * +:timeout+                  - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
       #
@@ -583,7 +584,7 @@ module Azure
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = blob_uri(container, blob, query)
-        
+
         headers = { }
 
         # set x-ms-blob-type to BlockBlob
@@ -601,6 +602,7 @@ module Azure
         headers["x-ms-blob-content-language"] = options[:blob_content_language] if options[:blob_content_language]
         headers["x-ms-blob-content-md5"] = options[:blob_content_md5] if options[:blob_content_md5]
         headers["x-ms-blob-cache-control"] = options[:blob_cache_control] if options[:blob_cache_control]
+        headers["x-ms-blob-content-disposition"] = options[:blob_content_disposition] if options[:blob_content_disposition]
 
         add_metadata_to_headers(options[:metadata], headers) if options[:metadata]
 
@@ -621,7 +623,7 @@ module Azure
       # * +blob+        - String. The blob name.
       # * +block_id+    - String. The block id. Note: this should be the raw block id, not Base64 encoded.
       # * +content+     - IO or String. The content of the blob.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -648,27 +650,27 @@ module Azure
       end
 
       # Public: Commits existing blob blocks to a blob.
-      #  
+      #
       # This method writes a blob by specifying the list of block IDs that make up the
-      # blob. In order to be written as part of a blob, a block must have been 
+      # blob. In order to be written as part of a blob, a block must have been
       # successfully written to the server in a prior create_blob_block method.
-      # 
-      # You can call Put Block List to update a blob by uploading only those blocks 
-      # that have changed, then committing the new and existing blocks together. 
-      # You can do this by specifying whether to commit a block from the committed 
+      #
+      # You can call Put Block List to update a blob by uploading only those blocks
+      # that have changed, then committing the new and existing blocks together.
+      # You can do this by specifying whether to commit a block from the committed
       # block list or from the uncommitted block list, or to commit the most recently
       # uploaded version of the block, whichever list it may belong to.
-      # 
+      #
       # ==== Attributes
       #
       # * +container+   - String. The container name.
       # * +blob+        - String. The blob name.
-      # * +block_list+  - Array. A ordered list of lists in the following format: 
+      # * +block_list+  - Array. A ordered list of lists in the following format:
       #   [ ["block_id1", :committed], ["block_id2", :uncommitted], ["block_id3"], ["block_id4", :committed]... ]
-      #   The first element of the inner list is the block_id, the second is optional 
-      #   and can be either :committed or :uncommitted to indicate in which group of blocks 
+      #   The first element of the inner list is the block_id, the second is optional
+      #   and can be either :committed or :uncommitted to indicate in which group of blocks
       #   the id should be looked for. If it is omitted, the latest of either group will be used.
-      # * +options+     - Hash. Optional parameters. 
+      # * +options+     - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -682,8 +684,8 @@ module Azure
       # * +:metadata+              - Hash. Custom metadata values to store with the blob.
       # * +:timeout+               - Integer. A timeout in seconds.
       #
-      # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx 
-      # 
+      # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx
+      #
       # Returns nil on success
       def commit_blob_blocks(container, blob, block_list, options={})
         query = { "comp" => "blocklist" }
@@ -699,6 +701,7 @@ module Azure
           headers["x-ms-blob-content-language"] = options[:blob_content_language] if options[:blob_content_language]
           headers["x-ms-blob-content-md5"] = options[:blob_content_md5] if options[:blob_content_md5]
           headers["x-ms-blob-cache-control"] = options[:blob_cache_control] if options[:blob_cache_control]
+          headers["x-ms-blob-content-disposition"] = options[:blob_content_disposition] if options[:blob_content_disposition]
 
           add_metadata_to_headers(options[:metadata], headers) if options[:metadata]
         end
@@ -709,12 +712,12 @@ module Azure
       end
 
       # Public: Retrieves the list of blocks that have been uploaded as part of a block blob.
-      # 
+      #
       # There are two block lists maintained for a blob:
-      # 1) Committed Block List: The list of blocks that have been successfully 
+      # 1) Committed Block List: The list of blocks that have been successfully
       #    committed to a given blob with commitBlobBlocks.
-      # 2) Uncommitted Block List: The list of blocks that have been uploaded for a 
-      #    blob using Put Block (REST API), but that have not yet been committed. 
+      # 2) Uncommitted Block List: The list of blocks that have been uploaded for a
+      #    blob using Put Block (REST API), but that have not yet been committed.
       #    These blocks are stored in Windows Azure in association with a blob, but do
       #    not yet form part of the blob.
       #
@@ -722,13 +725,13 @@ module Azure
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:blocklist_type+ - Symbol. One of :all, :committed, :uncommitted. Defaults to :all (optional)
-      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:timeout+        - Integer. A timeout in seconds.
       #
@@ -757,12 +760,12 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from.
       # * +:timeout+       - Integer. A timeout in seconds.
       #
@@ -792,12 +795,12 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from.
       # * +:timeout+       - Integer. A timeout in seconds.
       #
@@ -821,21 +824,21 @@ module Azure
         result
       end
 
-      # Public: Returns a list of active page ranges for a page blob. Active page ranges are 
+      # Public: Returns a list of active page ranges for a page blob. Active page ranges are
       # those that have been populated with data.
       #
       # ==== Attributes
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:start_range+    - Integer. Position of first byte of first page. (optional)
       # * +:end_range+      - Integer. Position of last byte of of last page. (optional)
-      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:timeout+        - Integer. A timeout in seconds.
       #
@@ -869,7 +872,7 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -878,34 +881,35 @@ module Azure
       # * +:content_encoding+         - String. Content encoding for the blob. Will be saved with blob.
       # * +:content_language+         - String. Content language for the blob. Will be saved with blob.
       # * +:content_md5+              - String. Content MD5 for the blob. Will be saved with blob.
+      # * +:content_disposition+      - String. Content disposition for the blob. Will be saved with blob.
       # * +:cache_control+            - String. Cache control for the blob. Will be saved with blob.
-      # * +:content_length+           - Integer. Resizes a page blob to the specified size. If the specified 
-      #   value is less than the current size of the blob, then all pages above 
-      #   the specified value are cleared. This property cannot be used to change 
-      #   the size of a block blob. Setting this property for a block blob returns 
+      # * +:content_length+           - Integer. Resizes a page blob to the specified size. If the specified
+      #   value is less than the current size of the blob, then all pages above
+      #   the specified value are cleared. This property cannot be used to change
+      #   the size of a block blob. Setting this property for a block blob returns
       #   status code 400 (Bad Request).
-      # * +:sequence_number_action+   - Symbol. This property indicates how the service should modify the sequence 
-      #   number for the blob. Required if :sequence_number is used. This property 
+      # * +:sequence_number_action+   - Symbol. This property indicates how the service should modify the sequence
+      #   number for the blob. Required if :sequence_number is used. This property
       #   applies to page blobs only.
       #
       #   Specify one of the following options for this property:
       #
-      #   * +:max+        - Sets the sequence number to be the higher of the value included with 
+      #   * +:max+        - Sets the sequence number to be the higher of the value included with
       #     the request and the value currently stored for the blob.
       #   * +:update+     - Sets the sequence number to the value included with the request.
-      #   * +:increment+  - Increments the value of the sequence number by 1. If specifying this 
+      #   * +:increment+  - Increments the value of the sequence number by 1. If specifying this
       #     option, do not include the sequence_number option; doing so will return
       #     status code 400 (Bad Request).
-      # * +:sequence_number+          - Integer. This property sets the blob's sequence number. The sequence number is a 
-      #   user-controlled property that you can use to track requests and manage concurrency 
-      #   issues. Required if the :sequence_number_action option is set to :max or :update. 
+      # * +:sequence_number+          - Integer. This property sets the blob's sequence number. The sequence number is a
+      #   user-controlled property that you can use to track requests and manage concurrency
+      #   issues. Required if the :sequence_number_action option is set to :max or :update.
       #   This property applies to page blobs only.
       #
-      #   Use this together with the :sequence_number_action to update the blob's sequence 
-      #   number, either to the specified value or to the higher of the values specified with 
+      #   Use this together with the :sequence_number_action to update the blob's sequence
+      #   number, either to the specified value or to the higher of the values specified with
       #   the request or currently stored with the blob.
       #
-      #   This header should not be specified if :sequence_number_action is set to :increment; 
+      #   This header should not be specified if :sequence_number_action is set to :increment;
       #   in this case the service automatically increments the sequence number by one.
       #
       #   To set the sequence number to a value of your choosing, this property must be specified
@@ -917,25 +921,26 @@ module Azure
       # The semantics for updating a blob's properties are as follows:
       #
       # * A page blob's sequence number is updated only if the request meets either of the following conditions:
-      # 
+      #
       #     * The :sequence_number_action property is set to :max or :update, and a value for :sequence_number is also set.
       #     * The :sequence_number_action property is set to :increment, indicating that the service should increment
       #       the sequence number by one.
-      # 
+      #
       # * The size of the page blob is modified only if a value for :content_length is specified.
       #
       # * If :sequence_number and/or :content_length are the only properties specified, then the other properties of the blob
       #   will NOT be modified.
-      # 
+      #
       # * If any one or more of the following properties are set, then all of these properties are set together. If a value is
       #   not provided for a given property when at least one of the properties listed below is set, then that property will be
       #   cleared for the blob.
-      # 
+      #
       #     * :cache_control
       #     * :content_type
       #     * :content_md5
       #     * :content_encoding
       #     * :content_language
+      #     * :content_disposition
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691966.aspx
       #
@@ -956,6 +961,7 @@ module Azure
           headers["x-ms-blob-content-length"] = options[:blob_content_length].to_s if options[:blob_content_length]
           headers["x-ms-blob-sequence-number-action"] = options[:sequence_number_action].to_s if options[:sequence_number_action]
           headers["x-ms-blob-sequence-number"] = options[:sequence_number].to_s if options[:sequence_number]
+          headers["x-ms-blob-content-disposition"] = options[:blob_content_disposition] if options[:blob_content_disposition]
         end
 
         call(:put, uri, nil, headers)
@@ -969,7 +975,7 @@ module Azure
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
       # * +metadata+       - Hash. The custom metadata.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -998,14 +1004,14 @@ module Azure
       #
       # * +container+        - String. The container name.
       # * +blob+             - String. The blob name.
-      # * +options+          - Hash. Optional parameters. 
+      # * +options+          - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:start_range+     - Integer. Position of first byte of first page. (optional)
       # * +:end_range+       - Integer. Position of last byte of of last page. (optional)
-      # * +:snapshot+        - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+        - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:get_content_md5+ - Boolean. Return the MD5 hash for the range. This option only valid if
       #   start_range and end_range are specified. (optional)
@@ -1039,18 +1045,18 @@ module Azure
       #
       # * +container+          - String. The container name.
       # * +blob+               - String. The blob name.
-      # * +options+            - Hash. Optional parameters. 
+      # * +options+            - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+          - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+          - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:delete_snapshots+  - Symbol. Used to specify the scope of the delete operation for snapshots.
-      #   This parameter is ignored if a blob does not have snapshots, or if a 
+      #   This parameter is ignored if a blob does not have snapshots, or if a
       #   snapshot is specified in the snapshot parameter. (optional)
-      # 
-      #   Possible values include:  
+      #
+      #   Possible values include:
       #   * +:only+     - Deletes only the snapshots for the blob, but leaves the blob
       #   * +:include+  - Deletes the blob and all of the snapshots for the blob
       # * +:timeout+           - Integer. A timeout in seconds.
@@ -1080,28 +1086,28 @@ module Azure
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:metadata+                 - Hash. Custom metadata values to store with the blob snapshot.
-      # * +:if_modified_since+        - A DateTime value. Specify this option to write the page only if the blob has been 
-      #   modified since the specified date/time. If the blob has not been modified, the 
+      # * +:if_modified_since+        - A DateTime value. Specify this option to write the page only if the blob has been
+      #   modified since the specified date/time. If the blob has not been modified, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:if_unmodified_since+      - A DateTime value. Specify this option to write the page only if the blob has not 
-      #   been modified since the specified date/time. If the blob has been modified, the 
+      # * +:if_unmodified_since+      - A DateTime value. Specify this option to write the page only if the blob has not
+      #   been modified since the specified date/time. If the blob has been modified, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:if_match+                 - An ETag value. Specify an ETag value to write the page only if the blob's ETag 
-      #   value matches the value specified. If the values do not match, the Blob service 
+      # * +:if_match+                 - An ETag value. Specify an ETag value to write the page only if the blob's ETag
+      #   value matches the value specified. If the values do not match, the Blob service
       #   returns status code 412 (Precondition Failed).
-      # * +:if_none_match+            - An ETag value. Specify an ETag value to write the page only if the blob's ETag 
-      #   value does not match the value specified. If the values are identical, the Blob 
+      # * +:if_none_match+            - An ETag value. Specify an ETag value to write the page only if the blob's ETag
+      #   value does not match the value specified. If the values are identical, the Blob
       #   service returns status code 412 (Precondition Failed).
       # * +:timeout+                  - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691971.aspx
-      # 
+      #
       # Returns the snapshot DateTime value
       def create_blob_snapshot(container, blob, options={})
         query = { "comp" => "snapshot" }
@@ -1125,58 +1131,58 @@ module Azure
       end
 
       # Public: Copies a source blob to a destination blob within the same storage account.
-      # 
+      #
       # ==== Attributes
       #
       # * +source_container+      - String. The destination container name to copy to.
       # * +source_blob+           - String. The destination blob name to copy to.
       # * +destination_container+ - String. The source container name to copy from.
       # * +destination_blob+      - String. The source blob name to copy from.
-      # * +options+               - Hash. Optional parameters. 
+      # * +options+               - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:source_snapshot+            - String. A snapshot id for the source blob
-      # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not 
-      #   specified, the operation will copy the source blob metadata to the destination 
-      #   blob. If this parameter is specified, the destination blob is created with the 
+      # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not
+      #   specified, the operation will copy the source blob metadata to the destination
+      #   blob. If this parameter is specified, the destination blob is created with the
       #   specified metadata, and metadata is not copied from the source blob.
-      # * +:source_if_modified_since+   - A DateTime value. Specify this option to write the page only if the source blob 
-      #   has been modified since the specified date/time. If the blob has not been 
+      # * +:source_if_modified_since+   - A DateTime value. Specify this option to write the page only if the source blob
+      #   has been modified since the specified date/time. If the blob has not been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
       # * +:source_if_unmodified_since+ - A DateTime value. Specify this option to write the page only if the source blob
-      #   has not been modified since the specified date/time. If the blob has been 
+      #   has not been modified since the specified date/time. If the blob has been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:source_if_match+            - An ETag value. Specify an ETag value to write the page only if the source blob's 
-      #   ETag value matches the value specified. If the values do not match, the Blob 
+      # * +:source_if_match+            - An ETag value. Specify an ETag value to write the page only if the source blob's
+      #   ETag value matches the value specified. If the values do not match, the Blob
       #   service returns status code 412 (Precondition Failed).
-      # * +:source_if_none_match+       - An ETag value. Specify an ETag value to write the page only if the source blob's 
-      #   ETag value does not match the value specified. If the values are identical, the 
+      # * +:source_if_none_match+       - An ETag value. Specify an ETag value to write the page only if the source blob's
+      #   ETag value does not match the value specified. If the values are identical, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_modified_since+     - A DateTime value. Specify this option to write the page only if the destination 
-      #   blob has been modified since the specified date/time. If the blob has not been 
+      # * +:dest_if_modified_since+     - A DateTime value. Specify this option to write the page only if the destination
+      #   blob has been modified since the specified date/time. If the blob has not been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_unmodified_since+   - A DateTime value. Specify this option to write the page only if the destination 
-      #   blob has not been modified since the specified date/time. If the blob has been 
+      # * +:dest_if_unmodified_since+   - A DateTime value. Specify this option to write the page only if the destination
+      #   blob has not been modified since the specified date/time. If the blob has been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_match+              - An ETag value. Specify an ETag value to write the page only if the destination 
-      #   blob's ETag value matches the value specified. If the values do not match, the 
+      # * +:dest_if_match+              - An ETag value. Specify an ETag value to write the page only if the destination
+      #   blob's ETag value matches the value specified. If the values do not match, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_none_match+         - An ETag value. Specify an ETag value to write the page only if the destination 
-      #   blob's ETag value does not match the value specified. If the values are 
+      # * +:dest_if_none_match+         - An ETag value. Specify an ETag value to write the page only if the destination
+      #   blob's ETag value does not match the value specified. If the values are
       #   identical, the Blob service returns status code 412 (Precondition Failed).
       # * +:timeout+                    - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
       #
-      # Returns a tuple of (copy_id, copy_status). 
+      # Returns a tuple of (copy_id, copy_status).
       #
-      # * +copy_id+     - String identifier for this copy operation. Use with get_blob or get_blob_properties to check 
+      # * +copy_id+     - String identifier for this copy operation. Use with get_blob or get_blob_properties to check
       #   the status of this copy operation, or pass to abort_copy_blob to abort a pending copy.
       # * +copy_status+ - String. The state of the copy operation, with these values:
       #   "success" - The copy completed successfully.
-      #   "pending" - The copy is in progress. 
+      #   "pending" - The copy is in progress.
       #
       def copy_blob(destination_container, destination_blob, source_container, source_blob, options={})
         query = { }
@@ -1209,13 +1215,13 @@ module Azure
       # ==== Attributes
       #
       # * +container+          - String. The container name.
-      # * +blob+               - String. The blob name.     
-      # * +options+            - Hash. Optional parameters. 
+      # * +blob+               - String. The blob name.
+      # * +options+            - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
-      # * +:duration+          - Integer. Default -1. Specifies the duration of the lease, in seconds, or negative one (-1) 
+      # Accepted key/value pairs in options parameter are:
+      # * +:duration+          - Integer. Default -1. Specifies the duration of the lease, in seconds, or negative one (-1)
       #   for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. (optional)
       # * +:proposed_lease_id+ - String. Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request)
       #   if the proposed lease ID is not in the correct format. (optional)
@@ -1223,7 +1229,7 @@ module Azure
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
       #
-      # Returns a String of the new unique lease id. While the lease is active, you must include the lease ID with any request 
+      # Returns a String of the new unique lease id. While the lease is active, you must include the lease ID with any request
       # to write to the blob, or to renew, change, or release the lease. A successful renew operation also returns the lease id
       # for the active lease.
       #
@@ -1245,9 +1251,9 @@ module Azure
         response.headers["x-ms-lease-id"]
       end
 
-      # Public: Renews the lease. The lease can be renewed if the lease ID specified on the request matches that 
-      # associated with the blob. Note that the lease may be renewed even if it has expired as long as the blob 
-      # has not been modified or leased again since the expiration of that lease. When you renew a lease, the 
+      # Public: Renews the lease. The lease can be renewed if the lease ID specified on the request matches that
+      # associated with the blob. Note that the lease may be renewed even if it has expired as long as the blob
+      # has not been modified or leased again since the expiration of that lease. When you renew a lease, the
       # lease duration clock resets.
       #
       # ==== Attributes
@@ -1255,11 +1261,11 @@ module Azure
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
       # * +lease+             - String. The lease id
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
+      # Accepted key/value pairs in options parameter are:
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
@@ -1279,8 +1285,8 @@ module Azure
         response.headers["x-ms-lease-id"]
       end
 
-      # Public: Releases the lease. The lease may be released if the lease ID specified on the request matches that 
-      # associated with the blob. Releasing the lease allows another client to immediately acquire the lease for 
+      # Public: Releases the lease. The lease may be released if the lease ID specified on the request matches that
+      # associated with the blob. Releasing the lease allows another client to immediately acquire the lease for
       # the blob as soon as the release is complete.
       #
       # ==== Attributes
@@ -1288,11 +1294,11 @@ module Azure
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
       # * +lease+             - String. The lease id.
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
+      # Accepted key/value pairs in options parameter are:
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
@@ -1312,38 +1318,38 @@ module Azure
         nil
       end
 
-      # Public: Breaks the lease, if the blob has an active lease. Once a lease is broken, it cannot be renewed. Any 
-      # authorized request can break the lease; the request is not required to specify a matching lease ID. When a 
-      # lease is broken, the lease break period is allowed to elapse, during which time no lease operation except 
-      # break and release can be performed on the blob. When a lease is successfully broken, the response indicates 
+      # Public: Breaks the lease, if the blob has an active lease. Once a lease is broken, it cannot be renewed. Any
+      # authorized request can break the lease; the request is not required to specify a matching lease ID. When a
+      # lease is broken, the lease break period is allowed to elapse, during which time no lease operation except
+      # break and release can be performed on the blob. When a lease is successfully broken, the response indicates
       # the interval in seconds until a new lease can be acquired.
       #
-      # A lease that has been broken can also be released, in which case another client may immediately acquire the 
+      # A lease that has been broken can also be released, in which case another client may immediately acquire the
       # lease on the blob.
       #
       # ==== Attributes
       #
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
-      # * +:break_period+     - Integer. The proposed duration of seconds that the lease should continue before it is 
-      #   broken, between 0 and 60 seconds. This break period is only used if it is shorter than 
-      #   the time remaining on the lease. If longer, the time remaining on the lease is used. A 
-      #   new lease will not be available before the break period has expired, but the lease may 
+      # Accepted key/value pairs in options parameter are:
+      # * +:break_period+     - Integer. The proposed duration of seconds that the lease should continue before it is
+      #   broken, between 0 and 60 seconds. This break period is only used if it is shorter than
+      #   the time remaining on the lease. If longer, the time remaining on the lease is used. A
+      #   new lease will not be available before the break period has expired, but the lease may
       #   be held for longer than the break period.
       #
-      #   If this option is not used, a fixed-duration lease breaks after the remaining lease 
+      #   If this option is not used, a fixed-duration lease breaks after the remaining lease
       #   period elapses, and an infinite lease breaks immediately.
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
       #
-      # Returns an Integer of the remaining lease time. This value is the approximate time remaining in the lease 
-      # period, in seconds. This header is returned only for a successful request to break the lease. If the break 
+      # Returns an Integer of the remaining lease time. This value is the approximate time remaining in the lease
+      # period, in seconds. This header is returned only for a successful request to break the lease. If the break
       # is immediate, 0 is returned.
       def break_lease(container, blob, options={})
         query = { "comp" => "lease" }

--- a/lib/azure/core/http/http_request.rb
+++ b/lib/azure/core/http/http_request.rb
@@ -95,7 +95,7 @@ module Azure
         def default_headers(current_time)
           headers["User-Agent"] = "Azure-SDK-For-Ruby/" + Azure::Version.to_s
           headers["x-ms-date"] = current_time
-          headers["x-ms-version"] = "2012-02-12"
+          headers["x-ms-version"] = "2013-08-15"
           headers["DataServiceVersion"] = "1.0;NetFx"
           headers["MaxDataServiceVersion"] = "2.0;NetFx"
 

--- a/test/unit/blob/blob_service_test.rb
+++ b/test/unit/blob/blob_service_test.rb
@@ -934,6 +934,11 @@ describe Azure::Blob::BlobService do
             subject.create_block_blob container_name, blob_name, content, { :blob_cache_control => "bcc-value" }
           end
 
+          it "modifies the request headers when provided a :blob_content_disposition value" do
+            request_headers["x-ms-blob-content-disposition"] = "bcd-value"
+            subject.create_block_blob container_name, blob_name, content, { :blob_content_disposition => "bcd-value" }
+          end
+
           it "modifies the request headers when provided a :content_type value" do
             request_headers["Content-Type"] = "ct-value"
             subject.create_block_blob container_name, blob_name, content, { :content_type => "ct-value" }
@@ -1035,6 +1040,11 @@ describe Azure::Blob::BlobService do
           it "modifies the request headers when provided a :blob_cache_control value" do
             request_headers["x-ms-blob-cache-control"] = "bcc-value"
             subject.commit_blob_blocks container_name, blob_name, block_list, { :blob_cache_control => "bcc-value" }
+          end
+
+          it "modifies the request headers when provided a :blob_content_disposition value" do
+            request_headers["x-ms-blob-content-disposition"] = "bcd-value"
+            subject.commit_blob_blocks container_name, blob_name, block_list, { :blob_content_disposition => "bcd-value" }
           end
 
           it "modifies the request headers when provided a :metadata value" do
@@ -1230,6 +1240,11 @@ describe Azure::Blob::BlobService do
           it "modifies the request headers when provided a :blob_cache_control value" do
             request_headers["x-ms-blob-cache-control"] = "bcc-value"
             subject.set_blob_properties container_name, blob_name, { :blob_cache_control => "bcc-value" }
+          end
+
+          it "modifies the request headers when provided a :blob_content_disposition value" do
+            request_headers["x-ms-blob-content-disposition"] = "bcd-value"
+            subject.set_blob_properties container_name, blob_name, { :blob_content_disposition => "bcd-value" }
           end
 
           it "modifies the request headers when provided a :blob_content_length value" do

--- a/test/unit/core/http/http_request_test.rb
+++ b/test/unit/core/http/http_request_test.rb
@@ -22,19 +22,19 @@ describe Azure::Core::Http::HttpRequest do
     end
 
     it "sets the x-ms-date header to the current_time" do
-      subject.headers["x-ms-date"] = "Thu, 04 Oct 2012 06:38:27 GMT"
+      subject.headers["x-ms-date"].must_equal "Thu, 04 Oct 2012 06:38:27 GMT"
     end
 
     it "sets the x-ms-version header to the current API version" do
-      subject.headers["x-ms-version"] = "2013-08-15"
+      subject.headers["x-ms-version"].must_equal "2013-08-15"
     end
 
     it "sets the DataServiceVersion header to the current API version" do
-      subject.headers["DataServiceVersion"] = "1.0;NetFx"
+      subject.headers["DataServiceVersion"].must_equal "1.0;NetFx"
     end
 
     it "sets the MaxDataServiceVersion header to the current max` API version" do
-      subject.headers["MaxDataServiceVersion"] = "2.0;NetFx"
+      subject.headers["MaxDataServiceVersion"].must_equal "2.0;NetFx"
     end
 
     describe " when passed a body " do

--- a/test/unit/core/http/http_request_test.rb
+++ b/test/unit/core/http/http_request_test.rb
@@ -17,7 +17,7 @@ require "azure/core/http/http_request"
 
 describe Azure::Core::Http::HttpRequest do
   describe " default_headers " do
-    subject do 
+    subject do
       Azure::Core::Http::HttpRequest.new(:get, URI("/"), nil, "Thu, 04 Oct 2012 06:38:27 GMT")
     end
 
@@ -26,7 +26,7 @@ describe Azure::Core::Http::HttpRequest do
     end
 
     it "sets the x-ms-version header to the current API version" do
-      subject.headers["x-ms-version"] = "2011-08-18"
+      subject.headers["x-ms-version"] = "2013-08-15"
     end
 
     it "sets the DataServiceVersion header to the current API version" do
@@ -38,7 +38,7 @@ describe Azure::Core::Http::HttpRequest do
     end
 
     describe " when passed a body " do
-      subject do 
+      subject do
         Azure::Core::Http::HttpRequest.new(:get, URI("/"), "<body/>")
       end
 


### PR DESCRIPTION
The version bump in `Azure::Core::Http:HttpRequest` is potentially breaking, but required to support the new field.

If it is breaking the bumped headers could be extracted and isolated to `BlobService` or only the affected methods.