### PR TITLE
match slightly less of the error message to work on osx

### DIFF
--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -422,7 +422,7 @@ describe Azure::VirtualMachineManagementService do
       exception = assert_raises(RuntimeError) do
         subject.add_role(windows_params, options)
       end
-      error_msg = 'No such file or directory -'
+      error_msg = 'No such file or directory'
       assert_match(/#{error_msg}/i, exception.message)
     end
 


### PR DESCRIPTION
The dash on the end of the line cause the message match to fail on OS X.