### PR TITLE
add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ nbproject/*
 
 
 .DS_Store
+.ruby-version


### PR DESCRIPTION
Simply add a .ruby-version to the .gitignore to be nice to people using rvm.