### PR TITLE
Allow all vm_sizes and warn if an unknown size

### DIFF
--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -522,15 +522,15 @@ module Azure
       end
 
       def validate_role_size(vm_size)
-        valid_role_sizes = %w(
+        suggested_role_sizes = %w(
           Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4
-          ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 A8 A9
+          ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 A8 A9 A10 A11
           Standard_D1 Standard_D2 Standard_D3 Standard_D4 Standard_D11 Standard_D12 Standard_D13 Standard_D14
           Standard_DS1 Standard_DS2 Standard_DS3 Standard_DS4 Standard_DS11 Standard_DS12 Standard_DS13 Standard_DS14
           Standard_G1 Standard_G2 Standard_G3 Standard_G4 Standard_G5
         )
-        if vm_size && !valid_role_sizes.include?(vm_size)
-          Loggerx.error_with_exit "Value '#{vm_size}' specified for parameter 'vm_size' is invalid. Allowed values are '#{valid_role_sizes.join(',')}'"
+        if vm_size && !suggested_role_sizes.include?(vm_size)
+          Loggerx.warn "Value '#{vm_size}' specified for parameter 'vm_size' is not in the list of valid VM role sizes. Suggested values are '#{suggested_role_sizes.join(',')}'"
         end
       end
 


### PR DESCRIPTION
Add A10 and A11 to valid role sizes...
But now only warn if a vm is not in the list of valid role sizes and allow Azure to decide whether it is valid or not at runtime.
Fixes #216 