### PR TITLE
default to the openssl environment variable name for ssl_cert_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ There are two ways you can set up the connections:
     AZURE_SQL_DATABASE_AUTHENTICATION_MODE = <:management_certificate or :sql_server>
     ```
     
-  * SSL CA_Certs [see gist](https://gist.github.com/fnichol/867550)
+  * [SSL Certificate File](https://gist.github.com/fnichol/867550)
     ```bash
-    AZURE_CA_FILE=<path to *.pem>
+    SSL_CERT_FILE=<path to *.pem>
     ```
 * Against local Emulator (Windows Only)
   * Storage

--- a/lib/azure/core.rb
+++ b/lib/azure/core.rb
@@ -37,5 +37,5 @@ Azure.configure do |config|
   config.sql_database_management_endpoint = ENV['AZURE_SQL_DATABASE_MANAGEMENT_ENDPOINT']
   config.sql_database_authentication_mode = ENV['AZURE_SQL_DATABASE_AUTHENTICATION_MODE']
 
-  config.ca_file = ENV['AZURE_CA_FILE']
+  config.ca_file = ENV['SSL_CERT_FILE']
 end


### PR DESCRIPTION
Change ENV['AZURE_CA_FILE'] to ENV['SSL_CERT_FILE'] so that it's inline with standard env var for cert files.