### PR TITLE
Missing ConfigurationSet for OS for custom images in request

### DIFF
--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -89,7 +89,7 @@ module Azure
             xml.OsVersion('i:nil' => 'true')
             xml.RoleType 'PersistentVMRole'
             xml.ConfigurationSets do
-              provisioning_configuration_to_xml(xml, params, options) if image.image_type == 'OS'
+              provisioning_configuration_to_xml(xml, params, options) if image.image_type == 'OS' || image.image_type == 'VM'
               xml.ConfigurationSet('i:type' => 'NetworkConfigurationSet') do
                 xml.ConfigurationSetType 'NetworkConfiguration'
                 xml.InputEndpoints do


### PR DESCRIPTION
Custom images are assigned an image_type of 'VM as compared to stock images, which have a type of 'OS'.

Without adding  || image.image_type == 'VM' at line 92 of serialization.rb, the serialized request does not contain a ConfigurationSet for the OS (only one for the network).