### PR TITLE
Provide sensical error message for invalid storage key

### DIFF
--- a/lib/azure/core/auth/signer.rb
+++ b/lib/azure/core/auth/signer.rb
@@ -30,6 +30,10 @@ module Azure
         # access_key - The access_key encoded in Base64. Defaults to the one
         #              in the global configuration.
         def initialize(access_key=Azure.config.storage_access_key)
+          if access_key.nil?
+            raise ArgumentError, "storage access key must be provided"
+          end
+
           @access_key = Base64.strict_decode64(access_key)
         end
 


### PR DESCRIPTION
We discovered this rather ugly error message:

    C:/ruby21-x64/lib/ruby/2.1.0/base64.rb:73:in `strict_decode64': undefined method `unpack' for nil:NilClass (NoMethodError)
    from C:/ruby21-x64/lib/ruby/gems/2.1.0/gems/azure-0.7.0.pre/lib/azure/core/auth/signer.rb:33:in `initialize'
        from C:/ruby21-x64/lib/ruby/gems/2.1.0/gems/azure-0.7.0.pre/lib/azure/core/auth/shared_key.rb:34:in `initialize'
        from C:/ruby21-x64/lib/ruby/gems/2.1.0/gems/azure-0.7.0.pre/lib/azure/service/storage_service.rb:25:in `new'
        from C:/ruby21-x64/lib/ruby/gems/2.1.0/gems/azure-0.7.0.pre/lib/azure/service/storage_service.rb:25:in `initialize'
        from C:/ruby21-x64/lib/ruby/gems/2.1.0/gems/azure-0.7.0.pre/lib/azure/queue/queue_service.rb:23:in `initialize'

This happens if you don't set the storage_access_key in Azure.config before attempting to access storage. The patch explicitly raises an ArgumentError instead, and tells you the real issue.