### PR TITLE
Add support for passing file content directly for management_certificate

### DIFF
--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -57,7 +57,7 @@ module Azure
         raise error_message if m_ep.nil? || m_ep.empty?
 
         m_cert = Azure.config.management_certificate
-        if m_cert =~ /(pem|pfx)$/ # validate only if input is file path
+        if File.file?(m_cert) && File.extname(m_cert).downcase =~ /(pem|pfx)$/ # validate only if input is file path
           error_message = "Could not read from file '#{m_cert}'."
           raise error_message unless test('r', m_cert)
         end


### PR DESCRIPTION
Merged master branch, resolved conflicts :collision: and refactored the file reading code :shower:.
 - resolved merge conflicts in base_management_service.rb
 - refactored code by moving cert file reading code to a private method named "read_cert_from_file"
