### PR TITLE
refactor http framework to use faraday

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015 Microsoft Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/azure.gemspec
+++ b/azure.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency('addressable',             '~> 2.3')
+  s.add_runtime_dependency('faraday',                 '~> 0.9')
+  s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
   s.add_runtime_dependency('json',                    '~> 1.8')
   s.add_runtime_dependency('mime-types',              '~> 2.0')
   s.add_runtime_dependency('nokogiri',                '~> 1.6')

--- a/lib/azure.rb
+++ b/lib/azure.rb
@@ -20,6 +20,8 @@ require 'openssl'
 require 'uri'
 require 'rexml/document'
 require 'addressable/uri'
+require 'faraday'
+require 'faraday_middleware'
 
 module Azure
   autoload :Client,                           'azure/client'
@@ -43,23 +45,35 @@ module Azure
     autoload :SqlManagementHttpRequest,       'azure/base_management/sql_management_http_request'
     autoload :BaseManagementService,          'azure/base_management/base_management_service'
     autoload :Location,                       'azure/base_management/location'
+    autoload :AffinityGroup,                  'azure/base_management/affinity_group'
+    autoload :Serialization,                  'azure/base_management/serialization'
   end
 
   module Blob
     autoload :BlobService,                    'azure/blob/blob_service'
+    autoload :Blob,                           'azure/blob/blob'
+    autoload :Block,                          'azure/blob/block'
+    autoload :Container,                      'azure/blob/container'
+    autoload :Serialization,                  'azure/blob/serialization'
   end
 
   module CloudServiceManagement
     autoload :CloudServiceManagementService,    'azure/cloud_service_management/cloud_service_management_service'
+    autoload :CloudService,                     'azure/cloud_service_management/cloud_service'
   end
 
   module Core
     autoload :Utility,                        'azure/core/utility'
     autoload :Error,                          'azure/core/error'
+    autoload :Service,                        'azure/core/service'
+    autoload :FilteredService,                'azure/core/filtered_service'
+    autoload :SignedService,                  'azure/core/signed_service'
   end
 
   module Queue
     autoload :QueueService,                   'azure/queue/queue_service'
+    autoload :Message,                        'azure/queue/message'
+    autoload :Queue,                          'azure/queue/queue'
   end
 
   module ServiceBus
@@ -74,11 +88,13 @@ module Azure
   module SqlDatabaseManagement
     autoload :SqlDatabaseManagementService,     'azure/sql_database_management/sql_database_management_service'
     autoload :Serialization,                    'azure/sql_database_management/serialization'
+    autoload :SqlServer,                        'azure/sql_database_management/sql_server'
   end
 
   module StorageManagement
     autoload :StorageManagementService,         'azure/storage_management/storage_management_service'
     autoload :Serialization,                    'azure/storage_management/serialization'
+    autoload :StorageAccount,                   'azure/storage_management/storage_account'
   end
 
   module Table
@@ -90,16 +106,20 @@ module Azure
   module VirtualMachineImageManagement
     autoload :VirtualMachineImageManagementService, 'azure/virtual_machine_image_management/virtual_machine_image_management_service'
     autoload :Serialization,                        'azure/virtual_machine_image_management/serialization'
+    autoload :VirtualMachineImage,                  'azure/virtual_machine_image_management/virtual_machine_image'
+    autoload :VirtualMachineDisk,                   'azure/virtual_machine_image_management/virtual_machine_disk'
   end
 
   module VirtualMachineManagement
     autoload :VirtualMachineManagementService,  'azure/virtual_machine_management/virtual_machine_management_service'
     autoload :Serialization,                    'azure/virtual_machine_management/serialization'
+    autoload :VirtualMachine,                   'azure/virtual_machine_management/virtual_machine'
   end
 
   module VirtualNetworkManagement
     autoload :VirtualNetworkManagementService,  'azure/virtual_network_management/virtual_network_management_service'
     autoload :Serialization,                    'azure/virtual_network_management/serialization'
+    autoload :VirtualNetwork,                   'azure/virtual_network_management/virtual_network'
   end
 
   class << self

--- a/lib/azure/core/http/http_error.rb
+++ b/lib/azure/core/http/http_error.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "azure/core/error"
+require 'azure/core/error'
 
 module Azure
   module Core
@@ -61,24 +61,22 @@ module Azure
         #
         # Returns nothing
         def parse_response
-          if @http_response.body && @http_response.body.include?("<")
+          if @http_response.body && @http_response.body.include?('<')
 
             document = Nokogiri.Slop(@http_response.body)
 
-            @type = document.css("code").first.text if document.css("code").any?
-            @type = document.css("Code").first.text if document.css("Code").any?
-            @description = document.css("message").first.text if document.css("message").any?
-            @description = document.css("Message").first.text if document.css("Message").any?
+            @type = document.css('code').first.text if document.css('code').any?
+            @type = document.css('Code').first.text if document.css('Code').any?
+            @description = document.css('message').first.text if document.css('message').any?
+            @description = document.css('Message').first.text if document.css('Message').any?
 
             # service bus uses detail instead of message
-            @detail = document.css("detail").first.text if document.css("detail").any?
-            @detail = document.css("Detail").first.text if document.css("Detail").any?
+            @detail = document.css('detail').first.text if document.css('detail').any?
+            @detail = document.css('Detail').first.text if document.css('Detail').any?
           else
-            @type = "Unknown"
+            @type = 'Unknown'
             if @http_response.body
-              @description = @http_response.body.strip
-            else
-              @description = @http_response.message.strip
+              @description = "#{@http_response.body.strip}"
             end
           end
         end

--- a/lib/azure/table/serialization.rb
+++ b/lib/azure/table/serialization.rb
@@ -17,19 +17,19 @@ require 'azure/service/serialization'
 require 'azure/table/guid'
 require 'azure/table/edmtype'
 
-require "time"
-require "date"
+require 'time'
+require 'date'
 
 module Azure
   module Table
     module Serialization
       include Azure::Service::Serialization
 
-      def self.hash_to_entry_xml(hash, id=nil, xml=Nokogiri::XML::Builder.new(:encoding => "UTF-8"))
+      def self.hash_to_entry_xml(hash, id=nil, xml=Nokogiri::XML::Builder.new(:encoding => 'UTF-8'))
         entry_namespaces = {
-          "xmlns"   => "http://www.w3.org/2005/Atom",
-          "xmlns:m" => "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata",
-          "xmlns:d" => "http://schemas.microsoft.com/ado/2007/08/dataservices"
+          'xmlns' => 'http://www.w3.org/2005/Atom',
+          'xmlns:m' => 'http://schemas.microsoft.com/ado/2007/08/dataservices/metadata',
+          'xmlns:d' => 'http://schemas.microsoft.com/ado/2007/08/dataservices'
         }
 
         xml.entry entry_namespaces do |entry|
@@ -45,19 +45,19 @@ module Azure
         xml
       end
 
-      def self.hash_to_content_xml(hash, xml=Nokogiri::XML::Builder.new(:encoding => "UTF-8"))
-        xml.send("content", :type => "application/xml") do |content|
-          content.send("m:properties") do |properties|
+      def self.hash_to_content_xml(hash, xml=Nokogiri::XML::Builder.new(:encoding => 'UTF-8'))
+        xml.send('content', :type => 'application/xml') do |content|
+          content.send('m:properties') do |properties|
             hash.each do |key, val|
-              key = key.encode("UTF-8") if key.is_a? String and !key.encoding.names.include?("BINARY")
-              val = val.encode("UTF-8") if val.is_a? String and !val.encoding.names.include?("BINARY")
+              key = key.encode('UTF-8') if key.is_a? String and !key.encoding.names.include?('BINARY')
+              val = val.encode('UTF-8') if val.is_a? String and !val.encoding.names.include?('BINARY')
 
               type = Azure::Table::EdmType.property_type(val)
               attributes = {}
-              attributes["m:type"] = type unless type.nil? || type.empty?
+              attributes['m:type'] = type unless type.nil? || type.empty?
 
               if val.nil?
-                attributes["m:null"] = "true"
+                attributes['m:null'] = 'true'
                 properties.send("d:#{key}", attributes)
               else
                 properties.send("d:#{key}", Azure::Table::EdmType.serialize_value(type, val), attributes)
@@ -71,16 +71,16 @@ module Azure
 
       def self.entries_from_feed_xml(xml)
         xml = slopify(xml)
-        expect_node("feed", xml)
+        expect_node('feed', xml)
 
-        return nil unless (xml > "entry").any?
+        return nil unless (xml > 'entry').any?
         
         results = []
         
-        if (xml > "entry").count == 0
-          results.push hash_from_entry_xml((xml > "entry"))
+        if (xml > 'entry').count == 0
+          results.push hash_from_entry_xml((xml > 'entry'))
         else
-          (xml > "entry").each do |entry|
+          (xml > 'entry').each do |entry|
             results.push hash_from_entry_xml(entry)
           end
         end
@@ -90,14 +90,14 @@ module Azure
 
       def self.hash_from_entry_xml(xml)
         xml = slopify(xml)
-        expect_node("entry", xml)
+        expect_node('entry', xml)
         result = {}
-        result[:etag] = xml["etag"]
-        result[:updated] = Time.parse((xml > "updated").text) if (xml > "updated").any?
+        result[:etag] = xml['etag']
+        result[:updated] = Time.parse((xml > 'updated').text) if (xml > 'updated').any?
         properties = {} 
-        if (xml > "content").any?
-          (xml > "content").first.first_element_child.element_children.each do |prop|
-            properties[prop.name] = prop.text != "" ? Azure::Table::EdmType.unserialize_query_value(prop.text, prop["m:type"]) : prop["null"] ? nil : ""
+        if (xml > 'content').any?
+          (xml > 'content').first.first_element_child.element_children.each do |prop|
+            properties[prop.name] = prop.text != '' ? Azure::Table::EdmType.unserialize_query_value(prop.text, prop['m:type']) : prop['null'] ? nil : ''
           end
         end
         result[:properties] = properties

--- a/test/integration/service_bus/queues_scenario_test.rb
+++ b/test/integration/service_bus/queues_scenario_test.rb
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "integration/test_helper"
+require 'integration/test_helper'
 
-describe "ServiceBus Queues Scenario" do
+describe 'ServiceBus Queues Scenario' do
   let(:queue_name) { ServiceBusQueueNameHelper.name }
 
   subject { Azure::ServiceBus::ServiceBusService.new }
@@ -23,18 +23,18 @@ describe "ServiceBus Queues Scenario" do
   def setup_queue()
     queues = subject.list_queues({ :skip => 20, :top => 2 })
     queues.each { |q|
-      ScenarioHelper.out "Queue name is " + q.name
+      ScenarioHelper.out 'Queue name is ' + q.name
     }
 
-    ScenarioHelper.out "checking if queue already exists " + queue_name
+    ScenarioHelper.out 'checking if queue already exists ' + queue_name
     begin
       subject.get_queue queue_name
-      ScenarioHelper.out "Queue already exists deleting it"
+      ScenarioHelper.out 'Queue already exists deleting it'
       subject.delete_queue queue_name
     rescue Azure::Core::Http::HTTPError => error
-      ScenarioHelper.out "could not get an existing queue (" + error.type + "), proceeding..."
+      ScenarioHelper.out 'could not get an existing queue (' + error.type + '), proceeding...'
       error.status_code.must_equal 404
-      error.type.must_equal "ResourceNotFound"
+      error.type.must_equal 'ResourceNotFound'
     end
 
     q = Azure::ServiceBus::Queue.new(queue_name, {
@@ -68,7 +68,7 @@ describe "ServiceBus Queues Scenario" do
           subject.send_queue_message queue_name, message
           success = true
         rescue Azure::Core::Http::HTTPError => error
-          ScenarioHelper.out "got error: " + error
+          ScenarioHelper.out 'got error: ' + error
           retry_counter = retry_counter + 1
           if retry_counter > 5
             throw error
@@ -137,9 +137,9 @@ describe "ServiceBus Queues Scenario" do
       subject.delete_queue_message message1again
       flunk 'Deleting a RECEIVEANDDELETE messasge should fail'
     rescue Azure::Core::Http::HTTPError => error
-      ScenarioHelper.out "As expected, could not delete a deleted message"
+      ScenarioHelper.out 'As expected, could not delete a deleted message'
       error.status_code.must_equal 400
-      error.type.must_equal "Unknown"
+      error.type.must_equal 'Unknown'
     end
 
     if expected_count > 0
@@ -189,7 +189,7 @@ describe "ServiceBus Queues Scenario" do
     message_count.must_equal 0
   end
 
-  it "should be able to upload many messages and read them back" do
+  it 'should be able to upload many messages and read them back' do
 
     setup_queue
 

--- a/test/integration/service_bus/subscriptions_test.rb
+++ b/test/integration/service_bus/subscriptions_test.rb
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "integration/test_helper"
+require 'integration/test_helper'
 
-describe "ServiceBus Subscriptions" do
+describe 'ServiceBus Subscriptions' do
   subject { Azure::ServiceBus::ServiceBusService.new }
   after { ServiceBusTopicNameHelper.clean }
   let(:topic){ ServiceBusTopicNameHelper.name }
-  let(:subscription) { "mySubscription" }
-  let(:subscription_alternative) { "mySubscription" }
+  let(:subscription) { 'mySubscription' }
+  let(:subscription_alternative) { 'mySubscription' }
   let(:description_alternative) {{
     :lock_duration => 'PT30S',
     :requires_session => true,
@@ -32,7 +32,7 @@ describe "ServiceBus Subscriptions" do
 
   before { subject.create_topic topic }
 
-  it "should be able to set description values to false" do
+  it 'should be able to set description values to false' do
     s = Azure::ServiceBus::Subscription.new(subscription, {
       :requires_session => false
     })
@@ -40,13 +40,13 @@ describe "ServiceBus Subscriptions" do
     s.requires_session.must_equal false
   end
 
-  it "should be able to create a new subscription" do
+  it 'should be able to create a new subscription' do
     result = subject.create_subscription topic, subscription
     result.must_be :kind_of?, Azure::ServiceBus::Subscription
     result.name.must_equal subscription
   end
 
-  it "should be able to create a new subscription from a string and description Hash" do
+  it 'should be able to create a new subscription from a string and description Hash' do
     result = subject.create_subscription topic, subscription_alternative, description_alternative
     result.must_be :kind_of?, Azure::ServiceBus::Subscription
     result.name.must_equal subscription_alternative
@@ -60,8 +60,8 @@ describe "ServiceBus Subscriptions" do
     result.enable_batched_operations.must_equal description_alternative[:enable_batched_operations]
   end
 
-  it "should be able to create a new subscription with objects" do
-    subscriptionObject = Azure::ServiceBus::Subscription.new "my_other_sub"
+  it 'should be able to create a new subscription with objects' do
+    subscriptionObject = Azure::ServiceBus::Subscription.new 'my_other_sub'
     subscriptionObject.topic = topic
     subscriptionObject.max_delivery_count = 3
 
@@ -73,19 +73,19 @@ describe "ServiceBus Subscriptions" do
     subject.delete_subscription result
   end
 
-  describe "when a subscription exists" do
+  describe 'when a subscription exists' do
     before { subject.create_subscription topic, subscription }
-    it "should be able to delete the subscription" do
+    it 'should be able to delete the subscription' do
       subject.delete_subscription topic, subscription
     end
 
-    it "should be able to get the subscription" do
+    it 'should be able to get the subscription' do
       result = subject.get_subscription topic, subscription
       result.must_be :kind_of?, Azure::ServiceBus::Subscription
       result.name.must_equal subscription
     end
 
-    it "should be able to list subscriptions" do
+    it 'should be able to list subscriptions' do
       result = subject.list_subscriptions topic
       subscription_found = false
       result.each { |s|
@@ -94,18 +94,18 @@ describe "ServiceBus Subscriptions" do
       assert subscription_found, "list_subscriptions didn't include the expected subscription"
     end
 
-    describe "when there are messages" do
+    describe 'when there are messages' do
       let(:msg) { 
-        m = Azure::ServiceBus::BrokeredMessage.new("some message body", {:prop1 => "val1"})
-        m.to = "me"
-        m.label = "my_label"
+        m = Azure::ServiceBus::BrokeredMessage.new('some message body', {:prop1 => 'val1'})
+        m.to = 'me'
+        m.label = 'my_label'
         m
       }
       before { 
         subject.send_topic_message topic, msg
       }
 
-      it "should be able to peek lock a message" do
+      it 'should be able to peek lock a message' do
         retrieved = subject.peek_lock_subscription_message topic, subscription
 
         retrieved.to.must_equal msg.to
@@ -116,7 +116,7 @@ describe "ServiceBus Subscriptions" do
         retrieved.must_be_nil
       end
 
-      it "should be able to read delete a message" do
+      it 'should be able to read delete a message' do
         retrieved = subject.read_delete_subscription_message topic, subscription
 
         retrieved.must_be :kind_of?, Azure::ServiceBus::BrokeredMessage
@@ -128,7 +128,7 @@ describe "ServiceBus Subscriptions" do
         retrieved.must_be_nil
       end
 
-      it "should be able to unlock a message" do
+      it 'should be able to unlock a message' do
         retrieved = subject.peek_lock_subscription_message topic, subscription, { :timeout => 1 }
         retrieved.body.must_equal msg.body
 
@@ -145,7 +145,7 @@ describe "ServiceBus Subscriptions" do
         retrieved.body.must_equal msg.body
       end
 
-      it "should be able to read a message from a subscription" do
+      it 'should be able to read a message from a subscription' do
         subject.send_topic_message topic, msg
         retrieved = subject.receive_subscription_message topic, subscription
 
@@ -164,7 +164,7 @@ describe "ServiceBus Subscriptions" do
         subject.create_subscription topic, subscription2
       }
 
-      it "should be able to list subscriptions" do
+      it 'should be able to list subscriptions' do
         result = subject.list_subscriptions topic
 
         subscription_found = false
@@ -180,7 +180,7 @@ describe "ServiceBus Subscriptions" do
         assert (subscription_found and subscription1_found and subscription2_found), "list_subscriptions didn't include the expected subscriptions"
       end
 
-      it "should be able to use $skip token" do
+      it 'should be able to use $skip token' do
         result = subject.list_subscriptions topic
         result2 = subject.list_subscriptions topic, { :skip => 1 }
         result2.length.must_equal result.length - 1
@@ -188,7 +188,7 @@ describe "ServiceBus Subscriptions" do
         result2[0].id.must_equal result[1].id
       end
       
-      it "should be able to use $top token" do
+      it 'should be able to use $top token' do
         result = subject.list_subscriptions topic
         result.length.wont_equal 1
         result.continuation_token.must_be_nil
@@ -200,7 +200,7 @@ describe "ServiceBus Subscriptions" do
         result2.length.must_equal 1
       end
 
-      it "should be able to use $skip and $top token together" do
+      it 'should be able to use $skip and $top token together' do
         result = subject.list_subscriptions topic
         result2 = subject.list_subscriptions topic, { :skip => 1, :top => 1 }
         result2.length.must_equal 1

--- a/test/unit/core/auth/shared_key_lite_test.rb
+++ b/test/unit/core/auth/shared_key_lite_test.rb
@@ -12,37 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "test_helper"
-require "azure/core/auth/shared_key_lite"
+require 'test_helper'
+require 'azure/core/auth/shared_key_lite'
 
 describe Azure::Core::Auth::SharedKeyLite do
-  subject { Azure::Core::Auth::SharedKeyLite.new "account-name", "YWNjZXNzLWtleQ==" }
+  subject { Azure::Core::Auth::SharedKeyLite.new 'account-name', 'YWNjZXNzLWtleQ==' }
   
-  let(:verb) { "POST" }
-  let(:uri) { URI.parse "http://dummy.uri/resource" }
+  let(:verb) { 'POST' }
+  let(:uri) { URI.parse 'http://dummy.uri/resource' }
   let(:headers) do
     {
-      "Content-MD5"=> "foo",
-      "Content-Type"=> "foo",
-      "Date"=> "foo"
+      'Content-MD5' => 'foo',
+      'Content-Type' => 'foo',
+      'Date' => 'foo'
     }
   end
   let(:headers_without_date) { 
     headers_without_date = headers.clone
-    headers_without_date.delete "Date"
+    headers_without_date.delete 'Date'
     headers_without_date
   }
   
-  describe "sign" do
-    it "creates a signature from the provided HTTP method, uri, and reduced set of standard headers" do
-      subject.sign(verb, uri, headers).must_equal "account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE="
+  describe 'sign' do
+    it 'creates a signature from the provided HTTP method, uri, and reduced set of standard headers' do
+      subject.sign(verb, uri, headers).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
     end
 
-    it "ignores standard headers other than Content-MD5, Content-Type, and Date" do
-      subject.sign(verb, uri, headers.merge({"Content-Encoding"=> "foo"})).must_equal "account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE="
+    it 'ignores standard headers other than Content-MD5, Content-Type, and Date' do
+      subject.sign(verb, uri, headers.merge({'Content-Encoding' => 'foo'})).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
     end
 
-    it "throws IndexError when there is no Date header" do
+    it 'throws IndexError when there is no Date header' do
       assert_raises IndexError do
         subject.sign(verb, uri, headers_without_date)
       end

--- a/test/unit/core/http/http_error_test.rb
+++ b/test/unit/core/http/http_error_test.rb
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "test_helper"
-require "azure/core/http/http_error"
+require 'test_helper'
+require 'azure/core/http/http_error'
 
 describe Azure::Core::Http::HTTPError do
   let :http_response do
-    stub(:body => Fixtures[:http_error], :status_code => 409, :uri => 'http://dummy.uri')
+    stub(body: Fixtures[:http_error], status_code: 409, uri: 'http://dummy.uri', headers: {})
   end
 
   subject do
     Azure::Core::Http::HTTPError.new(http_response)
   end
 
-  it "is an instance of Azure::Core::Error" do
+  it 'is an instance of Azure::Core::Error' do
     subject.must_be_kind_of Azure::Core::Error
   end
 
-  it "lets us see the original uri" do
+  it 'lets us see the original uri' do
     subject.uri.must_equal 'http://dummy.uri'
   end
 
@@ -37,26 +37,25 @@ describe Azure::Core::Http::HTTPError do
   end
 
   it "lets us see the error's type" do
-    subject.type.must_equal "TableAlreadyExists"
+    subject.type.must_equal 'TableAlreadyExists'
   end
 
   it "lets us see the error's description" do
-    subject.description.must_equal "The table specified already exists."
+    subject.description.must_equal 'The table specified already exists.'
   end
 
-  it "generates an error message that wraps both the type and description" do
-    subject.message.must_equal "TableAlreadyExists (409): The table specified already exists."
+  it 'generates an error message that wraps both the type and description' do
+    subject.message.must_equal 'TableAlreadyExists (409): The table specified already exists.'
   end
 
   describe 'with invalid http_response body' do
-
     let :http_response do
-      stub(:body => "\r\nInvalid request\r\n", :status_code => 409, :uri => 'http://dummy.uri')
+      stub(:body => "\r\nInvalid request\r\n", :status_code => 409, :uri => 'http://dummy.uri', headers: {})
     end
 
-    it "sets the type to unknown if the response body is not an XML" do
-      subject.type.must_equal "Unknown"
-      subject.description.must_equal "Invalid request"
+    it 'sets the type to unknown if the response body is not an XML' do
+      subject.type.must_equal 'Unknown'
+      subject.description.must_equal 'Invalid request'
     end
   end
 end

--- a/test/unit/core/http/http_request_test.rb
+++ b/test/unit/core/http/http_request_test.rb
@@ -16,9 +16,11 @@ require 'test_helper'
 require 'azure/core/http/http_request'
 
 describe Azure::Core::Http::HttpRequest do
+  let(:uri) { URI('http://example.com') }
+
   describe ' default_headers ' do
     subject do
-      Azure::Core::Http::HttpRequest.new(:get, URI('/'), body: nil, current_time: 'Thu, 04 Oct 2012 06:38:27 GMT')
+      Azure::Core::Http::HttpRequest.new(:get, uri, body: nil, current_time: 'Thu, 04 Oct 2012 06:38:27 GMT')
     end
 
     it 'sets the x-ms-date header to the current_time' do
@@ -36,101 +38,100 @@ describe Azure::Core::Http::HttpRequest do
     it 'sets the MaxDataServiceVersion header to the current max` API version' do
       subject.headers['MaxDataServiceVersion'] = '2.0;NetFx'
     end
+  end
 
-    let :http do
-      mock = Minitest::Mock.new
-      mock.expect(:use_ssl=, true, [true])
-      mock.expect(:verify_mode=, OpenSSL::SSL::VERIFY_PEER, [1])
-      mock.expect(:request, Net::HTTPResponse.new(1.1, 200, '<body/>'), [Net::HTTP::Get])
-      mock
+  describe 'when passed custom headers' do
+    subject do
+      Azure::Core::Http::HttpRequest.new(:get,
+                                         uri,
+                                         body: nil,
+                                         headers: {
+                                             'blah' => 'something',
+                                             'x-ms-version' => '123'
+                                         })
     end
 
-    describe 'when not using a ca_file' do
-      subject do
-        Azure::Core::Http::HttpRequest.new(:get,
-                                           URI('https://management.core.windows.net'),
-                                           body: nil,
-                                           current_time: 'Thu, 04 Oct 2012 06:38:27 GMT')
-      end
-
-      it 'should not set the ca_file on the http request' do
-        Net::HTTP.stub(:new, http) do
-          subject.call
-        end
-        http.verify
-      end
+    it 'should have overridden the value of x-ms-version' do
+      subject.headers['x-ms-version'].must_equal '123'
     end
 
-    describe 'when using a ca_file' do
-      before do
-        Azure.config.ca_file = './blah.pem'
-      end
-
-      after do
-        Azure.config.ca_file = nil
-      end
-
-      subject do
-        Azure::Core::Http::HttpRequest.new(:get,
-                                           URI('https://management.core.windows.net'),
-                                           body: nil,
-                                           current_time: 'Thu, 04 Oct 2012 06:38:27 GMT')
-      end
-
-      let :ca_http do
-        http.expect(:ca_file=, Azure.config.ca_file, [String])
-      end
-
-      it 'should set the ca_file on the http request' do
-        Net::HTTP.stub(:new, ca_http) do
-          subject.call
-        end
-        ca_http.verify
-      end
+    it 'should have added in the blah = something header' do
+      subject.headers['blah'].must_equal 'something'
     end
 
-    describe 'when passed custom headers' do
-      subject do
-        Azure::Core::Http::HttpRequest.new(:get, URI('/'),
-                                           body: nil,
-                                           headers: {
-                                               'blah' => 'something',
-                                               'x-ms-version' => '123'
-                                           })
-      end
+  end
 
-      it 'should have overridden the value of x-ms-version' do
-        subject.headers['x-ms-version'].must_equal '123'
-      end
-
-      it 'should have added in the blah = something header' do
-        subject.headers['blah'].must_equal 'something'
-      end
-
+  describe ' when passed a body ' do
+    subject do
+      Azure::Core::Http::HttpRequest.new(:post, uri, body: '<body/>')
     end
 
-    describe ' when passed a body ' do
-      subject do
-        Azure::Core::Http::HttpRequest.new(:get, URI('/'), body: '<body/>')
+    it 'sets the default Content-Type header' do
+      subject.headers['Content-Type'].must_equal 'application/atom+xml; charset=utf-8'
+    end
+
+    it 'sets the Content-Length header' do
+      subject.headers['Content-Length'].must_equal '7'
+    end
+
+    it 'sets the Content-MD5 header to a Base64 encoded representation of the MD5 hash of the body' do
+      subject.headers['Content-MD5'].must_equal 'PNeJy7qyzV4XUoBBHkVu0g=='
+    end
+  end
+
+  describe ' when the body is nil ' do
+    subject do
+      Azure::Core::Http::HttpRequest.new(:get, uri)
+    end
+
+    it 'leaves the Content-Type, Content-Length, and Content-MD5 headers blank' do
+      subject.headers['Content-Length'].must_equal '0'
+      subject.headers['Content-MD5'].must_be_nil
+    end
+  end
+
+  describe '#call' do
+
+    let(:mock_conn) do
+      conn = mock
+      conn.expects(:run_request, [uri, nil, nil]).returns(mock_res)
+      conn
+    end
+
+    subject do
+      sub = Azure::Core::Http::HttpRequest.new(:get, uri)
+      sub.expects(:http_setup).returns(mock_conn)
+      sub
+    end
+
+    describe 'on success' do
+      let(:body) { '</body>' }
+
+      let(:mock_res) do
+        res = mock
+        res.expects(:success?).returns(true)
+        res.expects(:body).returns(body)
+        res
       end
 
-      it 'sets the default Content-Type header' do
-        subject.headers['Content-Type'].must_equal 'application/atom+xml; charset=utf-8'
-      end
-
-      it 'sets the Content-Length header' do
-        subject.headers['Content-Length'].must_equal '7'
-      end
-
-      it 'sets the Content-MD5 header to a Base64 encoded representation of the MD5 hash of the body' do
-        subject.headers['Content-MD5'].must_equal 'PNeJy7qyzV4XUoBBHkVu0g=='
+      it 'should return a response' do
+        subject.call.body.must_equal(body)
       end
     end
 
-    describe ' when the body is nil ' do
-      it 'leaves the Content-Type, Content-Length, and Content-MD5 headers blank' do
-        subject.headers['Content-Length'].must_equal '0'
-        subject.headers['Content-MD5'].must_be_nil
+    describe 'on failure' do
+      let(:body) { 'OH NO!!' }
+
+      let(:mock_res) do
+        res = mock
+        res.expects(:success?).returns(false).at_least_once
+        res.expects(:status).returns(401).at_least_once
+        res.expects(:body).returns(body).at_least_once
+        res
+      end
+
+      it 'should return a response' do
+       -> { subject.call }.must_raise(Azure::Core::Http::HTTPError)
       end
     end
   end

--- a/test/unit/core/http/http_response_test.rb
+++ b/test/unit/core/http/http_response_test.rb
@@ -13,33 +13,8 @@
 # limitations under the License.
 #--------------------------------------------------------------------------
 require 'test_helper'
-require "azure/core/http/http_response"
+require 'azure/core/http/http_response'
 
 describe Azure::Core::Http::HttpResponse do
-  it "converts net/http headers into strings" do
-    http_response = MiniTest::Mock.new
-    http_response.stub(:to_hash, { "Content-Type" => ["text/xml"] })
-
-    response = Azure::Core::Http::HttpResponse.new(http_response)
-    response.headers["Content-Type"].must_equal "text/xml"
-  end
-
-  describe Azure::Core::Http::HttpResponse::HeaderHash do
-    subject do
-      Azure::Core::Http::HttpResponse::HeaderHash.new(
-        "AsdAsd" => ["1"], "bazqux" => ["2"], "QUXFOO" => ["3"]
-      )
-    end
-
-    it "returns the header values as strings, not arrays" do
-      subject["AsdAsd"].must_equal "1"
-      subject["bazqux"].must_equal "2"
-      subject["QUXFOO"].must_equal "3"
-    end
-
-    it "obtains keys in a case-insensitive fashion" do
-      subject["asdasd"].must_equal "1"
-      subject["BaZqUx"].must_equal "2"
-    end
-  end
+  # TODO: fill in with better tests.
 end

--- a/test/unit/core/http/retry_policy_test.rb
+++ b/test/unit/core/http/retry_policy_test.rb
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require "test_helper"
-require "azure/core/http/retry_policy"
+require 'test_helper'
+require 'azure/core/http/retry_policy'
 
 describe Azure::Core::Http::RetryPolicy do
-  it "uses blocks as retry logic" do
+  it 'uses blocks as retry logic' do
     retry_policy = Azure::Core::Http::RetryPolicy.new do |a,b| true end
     retry_policy.should_retry?(nil, nil).must_equal true
   end

--- a/test/unit/http_client_test.rb
+++ b/test/unit/http_client_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+describe Azure::HttpClient do
+  subject { Azure }
+
+  let :uri do
+    URI('https://management.core.windows.net')
+  end
+
+  describe '#agents' do
+
+    describe 'ssl vs non ssl uris' do
+      it 'should set verify true if using ssl' do
+        Azure.agents(uri).ssl[:verify].must_equal true
+      end
+
+      it 'should not set ssl if not using ssl' do
+        Azure.agents('http://localhost').ssl.must_be_empty
+      end
+    end
+
+    describe 'when using a ca_file' do
+      before do
+        Azure.config.ca_file = './blah.pem'
+      end
+
+      after do
+        Azure.config.ca_file = nil
+      end
+
+      it 'should set ca_file option on the http connection' do
+        Azure.agents(uri).ssl[:ca_file].must_equal './blah.pem'
+      end
+    end
+
+    describe 'when not using a ca_file' do
+      it 'should not set ca_file option on the http connection' do
+        Azure.agents(uri).ssl[:ca_file].must_be_nil
+      end
+    end
+
+    describe 'when using a http proxy' do
+      let(:proxy_uri){ URI('http://localhost:80') }
+
+      before do
+        ENV['HTTP_PROXY'] = proxy_uri.to_s
+      end
+
+      after do
+        ENV['HTTP_PROXY'] = nil
+      end
+
+      it 'should set the proxy configuration information on the http connection' do
+        Azure.agents(uri).proxy.uri.must_equal proxy_uri
+      end
+    end
+
+    describe 'when using a https proxy' do
+      let(:proxy_uri){ URI('https://localhost:443') }
+
+      before do
+        ENV['HTTPS_PROXY'] = proxy_uri.to_s
+      end
+
+      after do
+        ENV['HTTPS_PROXY'] = nil
+      end
+
+      it 'should set the proxy configuration information on the http connection' do
+        Azure.agents(uri).proxy.uri.must_equal proxy_uri
+      end
+    end
+  end
+end


### PR DESCRIPTION
- using faraday rather directly using net/http, which will allow us to get rid of the weird middleware stuff that we are doing in the service.rb and filter_service.rb.
- fixed up corp name and copyright dates in the license.txt
- added a bunch more autoloads
- cleaned up a bunch more of the double quotes