### PR TITLE
fix add_role: make sure that auto_generated certificate is uploaded

### DIFF
--- a/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -174,8 +174,8 @@ module Azure
         image = get_image(params[:image])
         options[:os_type] = image.os_type
         validate_deployment_params(params, options, true)
-        cloud_service = client.cloud_service_management
-        cloud_service = cloud_service.get_cloud_service_properties(params[:cloud_service_name])
+        cloud_services = client.cloud_service_management
+        cloud_service = cloud_services.get_cloud_service_properties(params[:cloud_service_name])
         deployment_name = cloud_service.deployment_name
         Azure::Loggerx.error_with_exit "Deployment doesn't exists." if cloud_service && deployment_name.empty?
         others = {}
@@ -195,6 +195,7 @@ module Azure
             existing_ports << endpoint[:public_port]
           end
         end
+        cloud_services.upload_certificate(options[:cloud_service_name], params[:certificate]) unless params[:certificate].empty?
         options[:existing_ports] = existing_ports
         body = Serialization.role_to_xml(params, image, options).to_xml
         path = "/services/hostedservices/#{cloud_service.name}/deployments/#{deployment_name}/roles"


### PR DESCRIPTION
Hello,

I've created an issue in Azure/vagrant-azure project because add_role was not working properly. It appears that this is due to the fact that the add_role method generates on the fly a certificate but does not upload it on Azure.

I've changed this.

Regards,