### PR TITLE
unify logging on virtual machine deletion

### DIFF
--- a/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -235,10 +235,10 @@ module Azure
           # Wait for 180s for disk to be released.
           disk = nil
           18.times do
-            print '# '
+            Azure::Loggerx.info '# '
             disk = disk_management_service.get_virtual_machine_disk(disk_name)
             unless disk.attached
-              print "Disk released.\n"
+              Azure::Loggerx.info "Disk released.\n"
               break
             end
             sleep 10


### PR DESCRIPTION
On Virtual Machine deletion there are printed some output directly to STDOUT and that breaks integration with other applications.

This PR fixes this by passing output to Logger like it is done elsewhere.

Fixes #200.