### PR TITLE
fix VirtualMachineDiskManagementService autoload

### DIFF
--- a/service_management/azure/lib/azure.rb
+++ b/service_management/azure/lib/azure.rb
@@ -106,6 +106,7 @@ module Azure
 
   module VirtualMachineImageManagement
     autoload :VirtualMachineImageManagementService, 'azure/virtual_machine_image_management/virtual_machine_image_management_service'
+    autoload :VirtualMachineDiskManagementService,  'azure/virtual_machine_image_management/virtual_machine_image_management_service'
     autoload :Serialization,                        'azure/virtual_machine_image_management/serialization'
     autoload :VirtualMachineImage,                  'azure/virtual_machine_image_management/virtual_machine_image'
     autoload :VirtualMachineDisk,                   'azure/virtual_machine_image_management/virtual_machine_disk'


### PR DESCRIPTION
Azure.vm_disk_management causes error because autoload for VirtualMachineDiskManagementService is missing. This PR fixes this issue. (fixes #269).
