### PR TITLE
Make add_data_disk more compliant with api and added instance ip support

### DIFF
--- a/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
@@ -106,6 +106,14 @@ module Azure
                   end
                   xml.StaticVirtualNetworkIPAddress options[:static_virtual_network_ipaddress] if options[:static_virtual_network_ipaddress]
                 end
+                if options[:instance_ip]
+                  xml.PublicIPs do
+                    xml.PublicIP do
+                      xml.Name options[:deployment_name]
+                      xml.DomainNameLabel options[:deployment_name]
+                    end
+                  end
+                end
               end
             end
             xml.VMImageName image.name if image.image_type == 'VM'
@@ -272,6 +280,10 @@ module Azure
               deployXML.css('Deployment'),
               'VirtualNetworkName'
             )
+            instance_ip =  xml_content(instance,
+              'PublicIPs PublicIP Address'
+            )
+            vm.instance_ip = instance_ip unless instance_ip.empty?
             roles.each do |role|
               if xml_content(role, 'RoleName') == role_name
                 vm.availability_set_name = xml_content(role, 'AvailabilitySetName')
@@ -281,7 +293,9 @@ module Azure
                   'ConfigurationSets ConfigurationSet SubnetNames SubnetName'
                 )
                 vm.subnet = subnet unless subnet.empty?
-                static_virtual_network_ipaddress =  xml_content(role,'ConfigurationSets ConfigurationSet StaticVirtualNetworkIPAddress')
+                static_virtual_network_ipaddress =  xml_content(role,
+                  'ConfigurationSets ConfigurationSet StaticVirtualNetworkIPAddress'
+                )
                 vm.static_virtual_network_ipaddress = static_virtual_network_ipaddress unless static_virtual_network_ipaddress.empty?
                 vm.os_type = xml_content(role, 'OSVirtualHardDisk OS')
                 vm.disk_name = xml_content(role, 'OSVirtualHardDisk DiskName')

--- a/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
@@ -409,24 +409,20 @@ module Azure
       end
 
       def self.add_data_disk_to_xml(vm, options)
-        if options[:import] && options[:disk_name].nil?
-          Azure::Loggerx.error_with_exit "The data disk name is not valid."
-        end
         media_link = vm.media_link
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.DataVirtualHardDisk(
             'xmlns' => 'http://schemas.microsoft.com/windowsazure',
             'xmlns:i' => 'http://www.w3.org/2001/XMLSchema-instance'
           ) do
-            xml.HostCaching options[:host_caching] || 'ReadOnly'
+            xml.HostCaching options[:host_caching] || 'None'
             xml.DiskLabel options[:disk_label]
-            xml.DiskName options[:disk_name] if options[:import]
+            xml.DiskName options[:disk_name]
             xml.LogicalDiskSizeInGB options[:disk_size] || 100
-            unless options[:import]
-              disk_name = media_link[/([^\/]+)$/]
-              media_link = media_link.gsub(/#{disk_name}/, (Time.now.strftime('disk_%Y_%m_%d_%H_%M_%S')) + '.vhd')
-              xml.MediaLink media_link
-            end
+            disk_name = media_link[/([^\/]+)$/]
+            media_link = media_link.gsub(/#{disk_name}/, (Time.now.strftime('disk_%Y_%m_%d_%H_%M_%S')) + '.vhd')
+            xml.MediaLink media_link
+            xml.SourceMediaLink options[:source_media_link]
           end
         end
         builder.doc.to_xml

--- a/service_management/azure/lib/azure/virtual_machine_management/virtual_machine.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/virtual_machine.rb
@@ -39,6 +39,7 @@ module Azure
       attr_accessor :data_disks
       attr_accessor :subnet
       attr_accessor :static_virtual_network_ipaddress
+      attr_accessor :instance_ip
     end
   end
 end

--- a/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -433,20 +433,18 @@ module Azure
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:import+        - Boolean. if true, then allows to use an existing
-      #  disk by disk name. if false, then create and attach new data disk.
-      # * +:disk_name+     - String. Specifies the name of the disk.
-      #   Reqruied if using existing disk.
-      # * +:host_caching+  - String. Specifies the caching behavior of data disk
+      # * +:disk_name+         - String. Specifies the name of the disk.
+      #   Required if using existing disk.
+      # * +:host_caching+      - String. Specifies the caching behavior of data disk
       #   The default is ReadOnly. Possible values are: None, ReadOnly, ReadWrite
-      # * +:disk_label+    - String. Specifies the description of the data disk.
-      # * +:disk_size+     - String. Specifies the size of disk in GB
+      # * +:disk_label+        - String. Specifies the description of the data disk.
+      # * +:disk_size+         - String. Specifies the size of disk in GB
+      # * +:source_media_link+ - String. Specifies the location of an existing vhd
       #
       # See http://msdn.microsoft.com/en-us/library/azure/jj157199.aspx
       #
       # Returns None
       def add_data_disk(vm_name, cloud_service_name, options = {})
-        options[:import] ||= false
         vm = get_virtual_machine(vm_name, cloud_service_name)
         if vm
           path = "/services/hostedservices/#{cloud_service_name}/deployments/#{vm.deployment_name}/roles/#{vm_name}/DataDisks"

--- a/service_management/azure/test/unit/virtual_machine_management/serialization_test.rb
+++ b/service_management/azure/test/unit/virtual_machine_management/serialization_test.rb
@@ -227,7 +227,6 @@ describe Azure::VirtualMachineManagement::Serialization do
     end
 
     it 'returns an xml for existing data disk' do
-      options[:import] = true
       options[:disk_name] = 'disk_name'
       result = subject.add_data_disk_to_xml(@vm, options)
       doc = Nokogiri::XML(result)
@@ -239,7 +238,6 @@ describe Azure::VirtualMachineManagement::Serialization do
     end
 
     it 'raise error when disk name is empty' do
-      options[:import] = true
       exception = assert_raises(RuntimeError) do
         subject.add_data_disk_to_xml(@vm, options)
       end


### PR DESCRIPTION
I have changed some parts so it's more compliant with http://msdn.microsoft.com/en-us/library/azure/jj157199.aspx :

HostCaching is None by default and not ReadOnly.
There is no need to use implicit import boolean because when you use a diskname which already exist it will import that disk and ignores options like disk size and media link.
Option SourceMediaLink was missing and is used to register an existing vhd as disk and attach it to the virtualmachine.

