### PR TITLE
Workaround don't set content encoding

### DIFF
--- a/service_management/azure/lib/azure/blob/blob_service.rb
+++ b/service_management/azure/lib/azure/blob/blob_service.rb
@@ -1379,16 +1379,16 @@ module Azure
 
           # Azure Storage Service expects content-encoding to be lowercase.
           # Authentication will fail otherwise.  
-          headers['Content-Encoding'].downcase!
+          # headers['Content-Encoding'].downcase!
         end
 
         response = super
 
         # Force the response.body to the content encoding of specified in the header.
         # content-encoding is echo'd back for the blob and is used to store the encoding of the octet stream
-        if !response.nil? && !response.body.nil? && response.headers['content-encoding']
-          response.body.force_encoding(response.headers['content-encoding'])
-        end
+        # if !response.nil? && !response.body.nil? && response.headers['content-encoding']
+        #   response.body.force_encoding(response.headers['content-encoding'])
+        # end
 
         response
       end

--- a/service_management/azure/lib/azure/blob/blob_service.rb
+++ b/service_management/azure/lib/azure/blob/blob_service.rb
@@ -1367,29 +1367,7 @@ module Azure
       end
 
       def call(method, uri, body=nil, headers=nil)
-        # Synchronize body and header encoding; header['Content-Encoding'] takes precedence. 
-        if headers && !body.nil?
-          # if headers['Content-Encoding'].nil?
-          #   headers['Content-Encoding'] = body.encoding.to_s if body.respond_to? :encoding # String
-          #   headers['Content-Encoding'] = body.external_encoding.to_s if body.respond_to? :external_encoding # IO
-          # else
-          #   body.force_encoding(headers['Content-Encoding']) if body.respond_to? :force_encoding # String
-          #   body.set_encoding(headers['Content-Encoding']) if body.respond_to? :set_encoding # IO
-          # end
-
-          # Azure Storage Service expects content-encoding to be lowercase.
-          # Authentication will fail otherwise.  
-          # headers['Content-Encoding'].downcase!
-        end
-
         response = super
-
-        # Force the response.body to the content encoding of specified in the header.
-        # content-encoding is echo'd back for the blob and is used to store the encoding of the octet stream
-        # if !response.nil? && !response.body.nil? && response.headers['content-encoding']
-        #   response.body.force_encoding(response.headers['content-encoding'])
-        # end
-
         response
       end
 

--- a/service_management/azure/lib/azure/blob/blob_service.rb
+++ b/service_management/azure/lib/azure/blob/blob_service.rb
@@ -1369,13 +1369,13 @@ module Azure
       def call(method, uri, body=nil, headers=nil)
         # Synchronize body and header encoding; header['Content-Encoding'] takes precedence. 
         if headers && !body.nil?
-          if headers['Content-Encoding'].nil?
-            headers['Content-Encoding'] = body.encoding.to_s if body.respond_to? :encoding # String
-            headers['Content-Encoding'] = body.external_encoding.to_s if body.respond_to? :external_encoding # IO
-          else
-            body.force_encoding(headers['Content-Encoding']) if body.respond_to? :force_encoding # String
-            body.set_encoding(headers['Content-Encoding']) if body.respond_to? :set_encoding # IO
-          end
+          # if headers['Content-Encoding'].nil?
+          #   headers['Content-Encoding'] = body.encoding.to_s if body.respond_to? :encoding # String
+          #   headers['Content-Encoding'] = body.external_encoding.to_s if body.respond_to? :external_encoding # IO
+          # else
+          #   body.force_encoding(headers['Content-Encoding']) if body.respond_to? :force_encoding # String
+          #   body.set_encoding(headers['Content-Encoding']) if body.respond_to? :set_encoding # IO
+          # end
 
           # Azure Storage Service expects content-encoding to be lowercase.
           # Authentication will fail otherwise.  


### PR DESCRIPTION
@devigned 

The content encoding of the blob is specified in `x-ms-blob-*` fields, e.g.  

```
x-ms-blob-content-type: application/json
x-ms-blob-content-encoding: gzip
```

The code breaks in `BlobService#call`, when `gzip` is used with the error message `Unknown encoding - gzip`. I remove the code the tries to enforce the encoding. 

Since I am not an expert on HTTP headers, I am not sure whether there are cases where this code breaks, but it works for gzip.
