### PR TITLE
fix raise "can't modify frozen string" exception in Ruby 2.3.0

### DIFF
--- a/service_management/azure/lib/azure/blob/blob_service.rb
+++ b/service_management/azure/lib/azure/blob/blob_service.rb
@@ -1378,8 +1378,8 @@ module Azure
           end
 
           # Azure Storage Service expects content-encoding to be lowercase.
-          # Authentication will fail otherwise.  
-          headers['Content-Encoding'].downcase!
+          # Authentication will fail otherwise.
+          headers['Content-Encoding'] = headers['Content-Encoding'].downcase
         end
 
         response = super


### PR DESCRIPTION
Azure::Blob::BlobService#create_block_blob raise "RuntimeError: can't modify frozen String" in Ruby 2.3.0 (See. Issue #313 ). This pull request fix.

In Ruby 2.3.0, Encoding#to_s return frozen String.

```ruby
[2] pry(main)> RUBY_VERSION
=> "2.2.4"
[3] pry(main)> "aaa".encoding.to_s.frozen?
=> false
[4] pry(main)> exit
[~]$ rbenv shell 2.3.0
[~]$ pry
[1] pry(main)> RUBY_VERSION
=> "2.3.0"
[2] pry(main)> "aaa".encoding.to_s.frozen?
=> true
[3] pry(main)>
```
