### PR TITLE
Pass custom_data to WindowsProvisioningConfiguration, if available

### DIFF
--- a/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
@@ -182,6 +182,7 @@ module Azure
               end
             end
             xml.AdminUsername params[:vm_user]
+            xml.CustomData params[:custom_data] if params[:custom_data]
           end
         end
       end


### PR DESCRIPTION
This enables classic machines to receive custom data as described at
https://msdn.microsoft.com/en-us/library/azure/jj157186.aspx#ConfigurationSets -> CustomData