### PR TITLE
Add delete_virtual_machine options to delete the associated VHD

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ vm_management.delete_endpoint('vm_name', 'cloud_service_name', 'endpoint_name')
 options = {
   :delete_vhd => true
 }
-vm_management.delete_virtual_machine('vm_name', 'cloud_service_name')
+vm_management.delete_virtual_machine('vm_name', 'cloud_service_name', options)
 
 # API to start deployment
 params = {

--- a/README.md
+++ b/README.md
@@ -480,6 +480,9 @@ vm_management.update_endpoints('vm_name', 'cloud_service_name', endpoint1, endpo
 vm_management.delete_endpoint('vm_name', 'cloud_service_name', 'endpoint_name')
 
 # API to delete Virtual Machine
+options = {
+  :delete_vhd => true
+}
 vm_management.delete_virtual_machine('vm_name', 'cloud_service_name')
 
 # API to start deployment

--- a/service_management/azure/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/service_management/azure/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -70,9 +70,9 @@ module Azure
       # Public: Deletes the specified data or operating system disk from the image repository.
       #
       # Returns None
-      def delete_virtual_machine_disk(disk_name)
+      def delete_virtual_machine_disk(disk_name, options={})
         Azure::Loggerx.info "Deleting Disk \"#{disk_name}\". "
-        path = "/services/disks/#{disk_name}"
+        path = "/services/disks/#{disk_name}#{ '?comp=media' if options[:delete_vhd] }"
         request = client.management_request(:delete, path)
         request.call
       end

--- a/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -209,14 +209,19 @@ module Azure
       #
       # ==== Attributes
       #
-      # * +vm_name+  - String. Virtual machine name.
+      # * +vm_name+             - String. Virtual machine name.
       # * +cloud_service_name+  - String. Cloud service name.
+      #
+      #  ==== Options
+      #
+      # Accepted key/value pairs are:
+      # * +delete_vhd+          - Boolean. To delete the associated VHD from the blob storage location.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/gg441305.aspx
       # See http://msdn.microsoft.com/en-us/library/azure/jj157179.aspx
       #
       # Returns NONE
-      def delete_virtual_machine(vm_name, cloud_service_name)
+      def delete_virtual_machine(vm_name, cloud_service_name, options={})
         virtual_machines = list_virtual_machines(cloud_service_name)
         vm = virtual_machines.select { |x| x.vm_name == vm_name }.first
         if vm
@@ -247,7 +252,7 @@ module Azure
           if disk.attached
             Azure::Loggerx.error "\nCannot delete disk #{disk_name}."
           else
-            disk_management_service.delete_virtual_machine_disk(disk_name)
+            disk_management_service.delete_virtual_machine_disk(disk_name, options)
           end
         else
           Azure::Loggerx.error "Cannot find virtual machine #{vm_name} under cloud service #{cloud_service_name}"

--- a/service_management/azure/test/integration/vm/VM_Delete_test.rb
+++ b/service_management/azure/test/integration/vm/VM_Delete_test.rb
@@ -21,6 +21,7 @@ describe Azure::VirtualMachineManagementService do
   let(:virtual_machine_name) { names.first }
   let(:csn) { names.last }
   let(:username) { 'admin' }
+
   before do
     Azure::Loggerx.expects(:puts).at_least_once.returns(nil)
     params = {
@@ -40,7 +41,10 @@ describe Azure::VirtualMachineManagementService do
   describe '#delete_virtual_machine' do
 
     it 'delete existing virtual machine and cloud service' do
-      subject.delete_virtual_machine(virtual_machine_name, csn)
+      options = {
+        delete_vhd: true,
+      }    
+      subject.delete_virtual_machine(virtual_machine_name, csn, options)
       vm = subject.get_virtual_machine(virtual_machine_name, csn)
       vm.must_be_nil
       cloud_service = Azure::CloudServiceManagementService.new


### PR DESCRIPTION
the Delete Disk operation does not delete the associated physical VHD file from the blob storage location by default. This PR allow to pass options on the delete_virtual_machine function to delete that VHD.

Ref: #148 