### PR TITLE
adding open_timeout default and correcting setting for read_timeout

### DIFF
--- a/service_management/azure/lib/azure.rb
+++ b/service_management/azure/lib/azure.rb
@@ -30,6 +30,7 @@ module Azure
   autoload :Default,                          'azure/default'
   autoload :HttpClient,                       'azure/http_client'
   autoload :Version,                          'azure/version'
+  autoload :HttpResponseHelper,               'azure/http_response_helper'
 
   # helpers because the naming is far too verbose
   autoload :BaseManagementService,                    'azure/base_management/base_management_service'

--- a/service_management/azure/lib/azure/base_management/management_http_request.rb
+++ b/service_management/azure/lib/azure/base_management/management_http_request.rb
@@ -51,6 +51,11 @@ module Azure
         res = conn.run_request(method.to_sym, uri, nil, nil) do  |req|
           req.body = body if body
           req.headers = headers if headers
+          unless headers.nil?
+            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
+            req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
+          end
+          req.options[:open_timeout] ||= 60
         end
         response = wait_for_completion(Azure::Core::Http::HttpResponse.new(res))
         Nokogiri::XML response.body unless response.nil?
@@ -119,6 +124,11 @@ module Azure
           res = conn.run_request(method.to_sym, URI(request_path), nil, nil) do  |req|
             req.body = body if body
             req.headers = headers if headers
+            unless headers.nil?
+              keep_alive = headers['Keep-Alive'] || headers['keep-alive']
+              req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
+            end
+            req.options[:open_timeout] ||= 60
           end
           response = Azure::Core::Http::HttpResponse.new(res)
           ret_val = Nokogiri::XML response.body
@@ -153,6 +163,11 @@ module Azure
         res = conn.run_request(method.to_sym, host_uri, nil, nil) do  |req|
           req.body = body if body
           req.headers = headers if headers
+          unless headers.nil?
+            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
+            req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
+          end
+          req.options[:open_timeout] ||= 60
         end
         wait_for_completion(HttpResponse.new(res))
       end

--- a/service_management/azure/lib/azure/base_management/management_http_request.rb
+++ b/service_management/azure/lib/azure/base_management/management_http_request.rb
@@ -48,15 +48,7 @@ module Azure
       # Returns a Nokogiri::XML instance of HttpResponse body
       def call
         conn = http_setup
-        res = conn.run_request(method.to_sym, uri, nil, nil) do  |req|
-          req.body = body if body
-          req.headers = headers if headers
-          unless headers.nil?
-            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
-            req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
-          end
-          req.options[:open_timeout] ||= 60
-        end
+        res = set_up_response(method.to_sym, uri, conn, headers ,body)
         response = wait_for_completion(Azure::Core::Http::HttpResponse.new(res))
         Nokogiri::XML response.body unless response.nil?
       end
@@ -121,15 +113,7 @@ module Azure
         done = false
         until done
           Azure::Loggerx.info('# ')
-          res = conn.run_request(method.to_sym, URI(request_path), nil, nil) do  |req|
-            req.body = body if body
-            req.headers = headers if headers
-            unless headers.nil?
-              keep_alive = headers['Keep-Alive'] || headers['keep-alive']
-              req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
-            end
-            req.options[:open_timeout] ||= 60
-          end
+          res = set_up_response(method.to_sym, URI(request_path), conn, headers ,body)
           response = Azure::Core::Http::HttpResponse.new(res)
           ret_val = Nokogiri::XML response.body
           status = xml_content(ret_val, 'Operation Status')
@@ -160,15 +144,7 @@ module Azure
       def rebuild_request(response)
         host_uri = URI.parse(response.headers['location'])
         conn = http_setup
-        res = conn.run_request(method.to_sym, host_uri, nil, nil) do  |req|
-          req.body = body if body
-          req.headers = headers if headers
-          unless headers.nil?
-            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
-            req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
-          end
-          req.options[:open_timeout] ||= 60
-        end
+        res = set_up_response(method.to_sym, host_uri, conn, headers ,body)
         wait_for_completion(HttpResponse.new(res))
       end
 

--- a/service_management/azure/lib/azure/core/http/http_request.rb
+++ b/service_management/azure/lib/azure/core/http/http_request.rb
@@ -120,14 +120,7 @@ module Azure
         end
 
         def http_setup
-          http = @client.agents(uri)
-
-          unless headers.nil?
-            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
-            http.read_timeout = keep_alive.split('=').last.to_i unless keep_alive.nil?
-          end
-
-          http
+          @client.agents(uri)
         end
 
         def body=(body)
@@ -143,6 +136,11 @@ module Azure
           res = conn.run_request(method.to_sym, uri, nil, nil) do |req|
             req.body = body if body
             req.headers = headers if headers
+            unless headers.nil?
+              keep_alive = headers['Keep-Alive'] || headers['keep-alive']
+              req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
+            end
+            req.options[:open_timeout] ||= 60
           end
 
           response = HttpResponse.new(res)

--- a/service_management/azure/lib/azure/core/http/http_request.rb
+++ b/service_management/azure/lib/azure/core/http/http_request.rb
@@ -26,7 +26,7 @@ module Azure
       # Represents a HTTP request can perform synchronous queries to a
       # HTTP server, returning a HttpResponse
       class HttpRequest
-
+        include Azure::HttpResponseHelper
         alias_method :_method, :method
 
         # The HTTP method to use (:get, :post, :put, :delete, etc...)
@@ -133,16 +133,7 @@ module Azure
         # @return [HttpResponse]
         def call
           conn = http_setup
-          res = conn.run_request(method.to_sym, uri, nil, nil) do |req|
-            req.body = body if body
-            req.headers = headers if headers
-            unless headers.nil?
-              keep_alive = headers['Keep-Alive'] || headers['keep-alive']
-              req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
-            end
-            req.options[:open_timeout] ||= 60
-          end
-
+          res = set_up_response(method.to_sym, uri, conn, headers ,body)
           response = HttpResponse.new(res)
           response.uri = uri
           raise response.error unless response.success?

--- a/service_management/azure/lib/azure/http_response_helper.rb
+++ b/service_management/azure/lib/azure/http_response_helper.rb
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+
+module Azure
+  module HttpResponseHelper
+
+      # Sends request to HTTP server and returns a Faraday::Response
+      # @param method   [Symbol] The HTTP method to use (:get, :post, :put, :del, etc...)
+      # @param url      [URI] The URI of the HTTP endpoint to query
+      # @param conn     [Net::HTTP] http agent for a given uri
+      # @param headers  [String] The request headers
+      # @param body     [String] The request body
+      #returns Faraday::Response
+      def set_up_response(method, url, conn, headers ,body)
+        conn.run_request(method, url, nil, nil) do |req|
+          req.body = body if body
+          req.headers = headers if headers
+          unless headers.nil?
+            keep_alive = headers['Keep-Alive'] || headers['keep-alive']
+            req.options[:timeout] = keep_alive.split('=').last.to_i unless keep_alive.nil?
+          end
+          req.options[:open_timeout] ||= 60
+        end
+      end
+  end
+end


### PR DESCRIPTION
Addressing issue #334 
Adding open_timeout default of 60 seconds, setting it in the Faraday connection. Also correcting setting for read_timeout as Faraday uses timeout.  
