### PR TITLE
Using only gemspec and branch to master for azure gem deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ deploy:
   api_key:
     secure: h1O/CbvwR2fsS013v7QAlW8qLIXrMDED9+HPDi5fM5o/Q/PU7uJTRI3Aold76xzXJj0eDloNIXlocdiYaJ3fh4u4UYv1HjTIW5yz9L30fjhuuWw7lMvBUHz0eYUTPWwWEZvp2aJY07C5KVRn+0sjZs9aKTUUIfFtHsW3uSZZpfY=
   gemspec: service_management/azure/azure.gemspec
-  gem:
-    master: azure
   on:
+    branch: master
     tags: true
     repo: Azure/azure-sdk-for-ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ deploy:
   api_key:
     secure: h1O/CbvwR2fsS013v7QAlW8qLIXrMDED9+HPDi5fM5o/Q/PU7uJTRI3Aold76xzXJj0eDloNIXlocdiYaJ3fh4u4UYv1HjTIW5yz9L30fjhuuWw7lMvBUHz0eYUTPWwWEZvp2aJY07C5KVRn+0sjZs9aKTUUIfFtHsW3uSZZpfY=
   gemspec: service_management/azure/azure.gemspec
+  gem: azure
   on:
     branch: master
     tags: true


### PR DESCRIPTION
Here is the successful azure gem build on private fork and the tag: 

Tag: v0.x.z
Travis File State: [https://github.com/vishrutshah/azure-sdk-for-ruby/blob/v0.x.z/.travis.yml](https://github.com/vishrutshah/azure-sdk-for-ruby/blob/v0.x.z/.travis.yml)
Travis-CI: [https://travis-ci.org/vishrutshah/azure-sdk-for-ruby/builds/124023566](https://travis-ci.org/vishrutshah/azure-sdk-for-ruby/builds/124023566)