### PR TITLE
Use custom dpl provider to handle gemspec with path parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ script:
 - cd ..
 deploy:
   provider: rubygems
+  edge:
+    source: vishrutshah/dpl
+    branch: gemspec_with_path
   api_key:
     secure: VXi28DFUnQ7tYuvOwwfs4Og0/Wkfq4GWMtU9Wjgn6VuYMuRMzMD34acIpgqCDW4dVLlsCtvx1MIZLvaHe0F5nOJP1LZ88IW8bDEa2dSRMhXXKGf/CF9sOhMxK9uoThMp7FHMSttfasudooIsrQn9FExdCs5s7ndDQ+gOD/QHKjk=
   gemspec: service_management/azure/azure.gemspec


### PR DESCRIPTION
Existing [rubygem provider](https://github.com/travis-ci/dpl/blob/2bf330d86c4503247815d0dd7a830882d9225888/lib/dpl/provider/rubygems.rb#L40) of [travis-ci/dpl](https://github.com/travis-ci/dpl) does not handle gempsec option when path to the *.gemspec file is supplied. In this case, it build the gem but doesn't publish it to the host. 

I've created a fork to handle the option of gemspec with path parameter. 
Successful MiniBuild: [https://travis-ci.org/vishrutshah/azure-sdk-for-ruby/builds/124298097](https://travis-ci.org/vishrutshah/azure-sdk-for-ruby/builds/124298097)
