### PR TITLE
Require azure/core before extending serialization class with it

### DIFF
--- a/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
+++ b/service_management/azure/lib/azure/virtual_machine_management/serialization.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
+require 'azure/core'
 require 'azure/virtual_machine_management/virtual_machine'
 require 'base64'
 


### PR DESCRIPTION
If you see line 22 in serialization.rb, it extends Azure::Core. This file is currently required by external libraries, like fog-azure, on its own. When it's required and azure/core has not been required previously, it'll crash.