### PR TITLE
Replace uuid gem with SecureRandom

### DIFF
--- a/service_management/azure/azure.gemspec
+++ b/service_management/azure/azure.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('nokogiri',                '~> 1.6')
   s.add_runtime_dependency('systemu',                 '~> 2.6')
   s.add_runtime_dependency('thor',                    '~> 0.19')
-  s.add_runtime_dependency('uuid',                    '~> 2.0')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')

--- a/service_management/azure/lib/azure/table/batch.rb
+++ b/service_management/azure/lib/azure/table/batch.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-require 'uuid'
+require 'securerandom'
 
 require 'azure/table/serialization'
 require 'azure/table/table_service'
@@ -54,9 +54,8 @@ module Azure
         @operations = []
         @entity_keys = []
         @table_service = Azure::Table::TableService.new
-        uuid = UUID.new
-        @batch_id = "batch_" + uuid.generate
-        @changeset_id = "changeset_" + uuid.generate
+        @batch_id = "batch_" + SecureRandom.uuid
+        @changeset_id = "changeset_" + SecureRandom.uuid
 
         self.instance_eval(&block) if block_given?
       end


### PR DESCRIPTION
SecureRandom is available in Ruby 1.9.3 or higher, providing a method
to generate UUIDs without the extra dependencies.