### PR TITLE
Blacklist strict-transport-security, it crashes the JSON parser when …

### DIFF
--- a/lib/azure/service_bus/brokered_message_serializer.rb
+++ b/lib/azure/service_bus/brokered_message_serializer.rb
@@ -93,6 +93,7 @@ module Azure
             connection
             content-type
             content-length
+            strict-transport-security
           )
 
           props = response.headers.reject do |k, _|


### PR DESCRIPTION
Work around the error Failed to receive message: 757: unexpected token at '{ "strict-transport-security" : max-age=31536000}', when receiving messages over the Azure Service Bus