### PR TITLE
Update Traffic Manager spec location from azure-rest-spi-specs repo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -370,7 +370,7 @@ REGEN_METADATA = {
         tag: 'arm_subs'
     },
     azure_mgmt_traffic_manager: {
-        spec_uri: 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-trafficmanager/2015-11-01/trafficmanager.json',
+        spec_uri: 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-trafficmanager/2015-11-01/swagger/trafficmanager.json',
         ns: 'Azure::ARM::TrafficManager',
         version: version,
         tag: 'arm_trafficmgr'

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -354,7 +354,7 @@
       ]
     },
     "azure_mgmt_traffic_manager": {
-      "swagger": "arm-trafficmanager/2015-11-01/trafficmanager.json",
+      "swagger": "arm-trafficmanager/2015-11-01/swagger/trafficmanager.json",
       "autorest_options": {
         "Namespace": "Azure::ARM::TrafficManager",
         "PackageName": "azure_mgmt_traffic_manager",


### PR DESCRIPTION
This is due to the PR https://github.com/Azure/azure-rest-api-specs/pull/461