### PR TITLE
[ASM] Blacklist strict-transport-security, it crashes the JSON parser when receiving Service Bus messages

### DIFF
--- a/lib/azure/service_bus/brokered_message_serializer.rb
+++ b/lib/azure/service_bus/brokered_message_serializer.rb
@@ -93,6 +93,7 @@ module Azure
             connection
             content-type
             content-length
+            strict-transport-security
           )
 
           props = response.headers.reject do |k, _|


### PR DESCRIPTION
Work around the error Failed to receive message: 757: unexpected token at '{ "strict-transport-security" : max-age=31536000}', when receiving messages over the Azure Service Bus

@slicke: I've cherry-picked your changes to make a PR into [asm branch](https://github.com/Azure/azure-sdk-for-ruby/tree/asm). Thanks a lot for your contributions. We appreciate your time and efforts. 

Reference PR https://github.com/Azure/azure-sdk-for-ruby/pull/401
Reference Issue https://github.com/Azure/azure-sdk-for-ruby/issues/400

Thanks!