### PR TITLE
Be inclusive of which files to bundle with gems

### DIFF
--- a/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
+++ b/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_batch/azure_mgmt_batch.gemspec
+++ b/azure_mgmt_batch/azure_mgmt_batch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
+++ b/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
+++ b/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
+++ b/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_compute/azure_mgmt_compute.gemspec
+++ b/azure_mgmt_compute/azure_mgmt_compute.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_compute/azure_mgmt_compute.gemspec
+++ b/azure_mgmt_compute/azure_mgmt_compute.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 1.9.3'
+
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10'
   spec.add_development_dependency 'rspec', '~> 3'

--- a/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
+++ b/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
+++ b/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
+++ b/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_dns/azure_mgmt_dns.gemspec
+++ b/azure_mgmt_dns/azure_mgmt_dns.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_features/azure_mgmt_features.gemspec
+++ b/azure_mgmt_features/azure_mgmt_features.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_graph/azure_mgmt_graph.gemspec
+++ b/azure_mgmt_graph/azure_mgmt_graph.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
+++ b/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
+++ b/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_locks/azure_mgmt_locks.gemspec
+++ b/azure_mgmt_locks/azure_mgmt_locks.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_logic/azure_mgmt_logic.gemspec
+++ b/azure_mgmt_logic/azure_mgmt_logic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
+++ b/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
+++ b/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_mobile_engagement/azure_mgmt_mobile_engagement.gemspec
+++ b/azure_mgmt_mobile_engagement/azure_mgmt_mobile_engagement.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_network/azure_mgmt_network.gemspec
+++ b/azure_mgmt_network/azure_mgmt_network.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
+++ b/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_policy/azure_mgmt_policy.gemspec
+++ b/azure_mgmt_policy/azure_mgmt_policy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
+++ b/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_redis/azure_mgmt_redis.gemspec
+++ b/azure_mgmt_redis/azure_mgmt_redis.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_resources/azure_mgmt_resources.gemspec
+++ b/azure_mgmt_resources/azure_mgmt_resources.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
+++ b/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_search/azure_mgmt_search.gemspec
+++ b/azure_mgmt_search/azure_mgmt_search.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_server_management/azure_mgmt_server_management.gemspec
+++ b/azure_mgmt_server_management/azure_mgmt_server_management.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
+++ b/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_sql/azure_mgmt_sql.gemspec
+++ b/azure_mgmt_sql/azure_mgmt_sql.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_storage/azure_mgmt_storage.gemspec
+++ b/azure_mgmt_storage/azure_mgmt_storage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
+++ b/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
+++ b/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_mgmt_web/azure_mgmt_web.gemspec
+++ b/azure_mgmt_web/azure_mgmt_web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/azure_sdk/azure_sdk.gemspec
+++ b/azure_sdk/azure_sdk.gemspec
@@ -15,8 +15,13 @@ Gem::Specification.new do |spec|
   spec.email         = 'azrubyteam@microsoft.com'
   spec.description   = 'Microsoft Azure SDK - Azure Client Library for Ruby'
   spec.summary       = 'Official Ruby client library to consume Microsoft Azure services.'
-  spec.homepage      = 'http://github.com/azure/azure-sdk-ruby'
+  spec.homepage      = 'https://aka.ms/azure-sdk-for-ruby'
   spec.license       = 'MIT'
+
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
This change is about being inclusive on which files to be bundled with gems instead of rejecting files do not required from git ls-files -z

This way we will not unintentional bundle files like Gemfile, *.gemspec, Rakefile etc... like we already did that until recently.