### PR TITLE
Adding require for azure/core and autoload Auth::SharedAccessSigner

### DIFF
--- a/lib/azure.rb
+++ b/lib/azure.rb
@@ -76,9 +76,11 @@ module Azure
     autoload :SqlFilter,                'azure/service_bus/sql_filter'
     autoload :TrueFilter,               'azure/service_bus/true_filter'
     autoload :CorrelationFilter,        'azure/service_bus/correlation_filter'
+
     module Auth
       autoload :SharedAccessSigner,     'azure/service_bus/auth/shared_access_signer'
     end
+
   end
 
   module SqlDatabaseManagement

--- a/lib/azure.rb
+++ b/lib/azure.rb
@@ -22,6 +22,7 @@ require 'rexml/document'
 require 'addressable/uri'
 require 'faraday'
 require 'faraday_middleware'
+require 'azure/core'
 
 module Azure
   autoload :Client,                           'azure/client'
@@ -75,6 +76,9 @@ module Azure
     autoload :SqlFilter,                'azure/service_bus/sql_filter'
     autoload :TrueFilter,               'azure/service_bus/true_filter'
     autoload :CorrelationFilter,        'azure/service_bus/correlation_filter'
+    module Auth
+      autoload :SharedAccessSigner,     'azure/service_bus/auth/shared_access_signer'
+    end
   end
 
   module SqlDatabaseManagement


### PR DESCRIPTION
Adding require for azure/core and autoload Auth::SharedAccessSigner, so they don't need to be required from the caller. This needs also a change in azure-core, as azure-core is currently not autoloading auth files, see PR https://github.com/Azure/azure-ruby-asm-core/pull/25.