### PR TITLE
Revert "Use only asm branch to release azure gem (#420)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ deploy:
   on:
     tags: true
     repo: Azure/azure-sdk-for-ruby
-    branch: asm


### PR DESCRIPTION
This reverts commit 13551d6ad045cca1cce956d7e506db8757d8ad97.

Based on the [documentation](https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A) when `tag` is `true` then `branch` condition is ignored. Thanks @veronicagg for pointing this out. 