### PR TITLE
Fixing arm:regen in rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,13 +120,9 @@ end
 
 def each_gem
   each_child do |dir|
-    if REGEN_METADATA.has_key?(dir.to_sym)
-      yield dir
-    end
-    if dir.include?('/')
-      if REGEN_METADATA.has_key?(dir.split('/').last.to_sym)
-        yield dir
-      end
+    gem_dir = dir.split('/').last.to_sym
+    if REGEN_METADATA.has_key?(gem_dir)
+      yield gem_dir
     end
   end
 end


### PR DESCRIPTION
arm:regen was failing due to dir having "management/" in the string, as it was not finding this in REGEN_METADATA at https://github.com/Azure/azure-sdk-for-ruby/blob/master/Rakefile#L59