### PR TITLE
Updating to fixed version of autorest temporarily

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -2,7 +2,7 @@
   "meta": {
     "version": "0.1.0",
     "language": "Ruby",
-    "autorest": "latest"
+    "autorest": "0.17.0-Nightly20161018"
   },
   "projects": {
     "azure_mgmt_authorization": {


### PR DESCRIPTION
Updating swagger to sdk config to fixed version of autorest temporarily, since latest nightly of autorest is broken, and using latest is causing jobs in azure-rest-api-specs repo to fail.