### PR TITLE
Ignore query parameters on recording playback

### DIFF
--- a/vcr_helper.rb
+++ b/vcr_helper.rb
@@ -16,7 +16,7 @@ if !ENV['INTEG_RECORDED'].nil? && ENV['INTEG_RECORDED'] == 'true'
 end
 
 VCR.configure do |config|
-  config.default_cassette_options = {:record => :once, :allow_playback_repeats => true }
+  config.default_cassette_options = {:record => :once, :match_requests_on => [:host, :path], :allow_playback_repeats => true}
   config.hook_into :faraday
   config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = "spec/vcr_cassettes"

--- a/vcr_helper.rb
+++ b/vcr_helper.rb
@@ -16,7 +16,7 @@ if !ENV['INTEG_RECORDED'].nil? && ENV['INTEG_RECORDED'] == 'true'
 end
 
 VCR.configure do |config|
-  config.default_cassette_options = {:record => :once, :match_requests_on => [:host, :path], :allow_playback_repeats => true}
+  config.default_cassette_options = {:record => :once, :match_requests_on => [:method, :host, :path], :allow_playback_repeats => true}
   config.hook_into :faraday
   config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = "spec/vcr_cassettes"


### PR DESCRIPTION
#521

Reference: https://www.relishapp.com/vcr/vcr/v/1-7-1/docs/cassettes/request-matching#match-on-host-and-path-(to-ignore-query-params)

With this fix in the recordings pattern matching, we'd not need to re-record recordings in case the query parameters changes (Ex. api_version) in the new swagger. 
