### PR TITLE
Extend user_agent_extended array to add telemetry information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ script:
 - bundle exec rake arm:build
 - unset BUNDLE_GEMFILE
 - cd $TRAVIS_BUILD_DIR/runtime/ms_rest && bundle install --gemfile=Gemfile && bundle exec rspec
-- unset BUNDLE_GEMFILE
 - cd $TRAVIS_BUILD_DIR/runtime/ms_rest_azure && bundle install --gemfile=Gemfile && bundle exec rspec
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ rvm:
 - 2.2.0
 - 2.3.0
 script:
-- cd $TRAVIS_BUILD_DIR/runtime/ms_rest && bundle install && bundle exec rspec
-- cd $TRAVIS_BUILD_DIR/runtime/ms_rest_azure && bundle install && bundle exec rspec
-- cd $TRAVIS_BUILD_DIR
-- bundle install
+- gem install bundler
 - if [ "$INTEG_RECORDED" == "true" ] ; then bundle exec rake arm:spec ; fi
 - bundle exec rake arm:build
+- unset BUNDLE_GEMFILE
+- cd $TRAVIS_BUILD_DIR/runtime/ms_rest && bundle install --gemfile=Gemfile && bundle exec rspec
+- unset BUNDLE_GEMFILE
+- cd $TRAVIS_BUILD_DIR/runtime/ms_rest_azure && bundle install --gemfile=Gemfile && bundle exec rspec
 deploy:
   provider: script
   script: ./scripts/release.sh

--- a/runtime/ms_rest/lib/ms_rest/http_operation_request.rb
+++ b/runtime/ms_rest/lib/ms_rest/http_operation_request.rb
@@ -103,7 +103,7 @@ module MsRest
     end
     
     def user_agent
-      "Azure-SDK-For-Ruby/#{MsRest::VERSION}/#{user_agent_extended.join('/')}"
+      "Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM}) #{user_agent_extended.join(' ')}"
     end
     
     def to_json(*a)

--- a/runtime/ms_rest_azure/Gemfile
+++ b/runtime/ms_rest_azure/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'ms_rest', path: '../ms-rest'
+  gem 'ms_rest', path: '../ms_rest'
 end
 
 group :test do

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
@@ -19,6 +19,8 @@ module MsRestAzure
       @request_headers =  {
           'Content-Type' => 'application/json;charset=utf-8' # This is the current default for Azure services, and content-type supported by Autorest
       }
+      add_user_agent_information("ms_rest_azure/#{MsRestAzure::VERSION}")
+      add_user_agent_information("Azure-SDK-For-Ruby")
     end
 
     #
@@ -40,11 +42,11 @@ module MsRestAzure
         task = Concurrent::TimerTask.new do
           begin
             if !polling_state.azure_async_operation_header_link.nil?
-              update_state_from_azure_async_operation_header(polling_state.get_request(headers: request.headers, base_uri: request.base_uri), polling_state)
+              update_state_from_azure_async_operation_header(polling_state.get_request(headers: request.headers, base_uri: request.base_uri, user_agent_extended: user_agent_extended), polling_state)
             elsif !polling_state.location_header_link.nil?
-              update_state_from_location_header(polling_state.get_request(headers: request.headers, base_uri: request.base_uri), polling_state, custom_deserialization_block)
+              update_state_from_location_header(polling_state.get_request(headers: request.headers, base_uri: request.base_uri, user_agent_extended: user_agent_extended), polling_state, custom_deserialization_block)
             elsif http_method === :put
-              get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, :get, {query_params: request.query_params, headers: request.headers})
+              get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, :get, {query_params: request.query_params, headers: request.headers, user_agent_extended: user_agent_extended})
               update_state_from_get_resource_operation(get_request, polling_state, custom_deserialization_block)
             else
               task.shutdown
@@ -252,7 +254,6 @@ module MsRestAzure
 
       result
     end
-
 
     private
       #

--- a/runtime/ms_rest_azure/spec/azure_service_client_spec.rb
+++ b/runtime/ms_rest_azure/spec/azure_service_client_spec.rb
@@ -104,5 +104,21 @@ module MsRestAzure
         expect { azure_service_client.get_long_running_operation_result(azure_response, nil) }.to raise_error(AzureOperationError)
       end
     end
+
+    it 'should add or update default user agent information' do
+      azure_service_client = AzureServiceClient.new nil
+
+      # Verify default information
+      default_info = 'Azure-SDK-For-Ruby'
+      expect(azure_service_client.user_agent_extended).not_to be_nil
+      expect(azure_service_client.user_agent_extended).to include(default_info)
+
+      # Verify updated information
+      additional_user_agent_information = "fog-azure-rm/0.2.0"
+      azure_service_client.add_user_agent_information(additional_user_agent_information)
+      expect(azure_service_client.user_agent_extended).not_to be_nil
+      expect(azure_service_client.user_agent_extended).to include(default_info)
+      expect(azure_service_client.user_agent_extended).to include(additional_user_agent_information)
+    end
   end
 end


### PR DESCRIPTION
This is part of the feature #517. We've exposed `user_agent_extended` array on the [ServiceClient ](https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest/lib/ms_rest/service_client.rb#L9) of `ms_rest` to be used for appending additional telemetry information to be sent via `User-Agent` header. 

**User-Agent Header Before** from [AzureServiceClient](https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb#L9)
```
Azure-SDK-For-Ruby/0.6.0/
```

**User-Agent Header After** from [AzureServiceClient](https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb#L9)
```
Ruby/2.2.4 (x86_64-darwin15) ms_rest/0.6.0 ms_rest_azure/0.6.0 Azure-SDK-For-Ruby
```

After this change, we can also leverage [add_user_agent_information](https://github.com/Azure/azure-sdk-for-ruby/pull/543/files#diff-3970cf987aba9f07068141e4e141d0e7R71) method to add more information about azure_mgmt_* sdks from each of the management clients & consumer of azure_mgmt_* sdks can also append more information as well for us to have rich telemetry. 