### PR TITLE
add model to_json, from_json and to_s mixin

### DIFF
--- a/runtime/ms_rest/lib/ms_rest.rb
+++ b/runtime/ms_rest/lib/ms_rest.rb
@@ -23,6 +23,7 @@ require 'ms_rest/http_operation_request'
 require 'ms_rest/http_operation_error'
 require 'ms_rest/retry_policy_middleware'
 require 'ms_rest/service_client'
+require 'ms_rest/jsonable'
 
 module MsRest end
 module MsRest::Serialization end

--- a/runtime/ms_rest/lib/ms_rest/jsonable.rb
+++ b/runtime/ms_rest/lib/ms_rest/jsonable.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+module MsRest
+  # Mixin to provide simple serialization / deserialization in AutoRest generated model classes
+  module JSONable
+    include MsRest::Serialization
+
+    #
+    # Serialize the object to JSON
+    # @return [String] JSON serialized version of the object
+    #
+    def to_json
+      serialize(self.class.mapper, self)
+    end
+
+    #
+    # Deserialize the object from JSON
+    # @param json [String] JSON string representation of the object
+    # @return [JSONable] object built from json input
+    #
+    def from_json(json)
+      deserialize(self.class.mapper, json)
+    end
+
+    #
+    # String representation of the object
+    # @return [String]
+    #
+    def to_s
+      "#{super} #{to_json.to_s}"
+    end
+  end
+end

--- a/runtime/ms_rest/lib/ms_rest/serialization.rb
+++ b/runtime/ms_rest/lib/ms_rest/serialization.rb
@@ -15,7 +15,7 @@ module MsRest
     # @param response_body [Hash] Ruby Hash object to deserialize.
     # @param object_name [String] Name of the deserialized object.
     #
-    def deserialize(mapper, response_body, object_name)
+    def deserialize(mapper, response_body, object_name = nil)
       build_serializer.deserialize(mapper, response_body, object_name)
     end
 
@@ -26,7 +26,7 @@ module MsRest
     # @param object [Object] Ruby object to serialize.
     # @param object_name [String] Name of the serialized object.
     #
-    def serialize(mapper, object, object_name)
+    def serialize(mapper, object, object_name = nil)
       build_serializer.serialize(mapper, object, object_name)
     end
 
@@ -391,7 +391,14 @@ module MsRest
       # @param model_name [String] Name of the model to retrieve.
       #
       def get_model(model_name)
-        Object.const_get(@context.class.to_s.split('::')[0...-1].join('::') + "::Models::#{model_name}")
+        consts = @context.class.to_s.split('::')
+        if consts.any?{ |const| const == 'Models' }
+          # context is a model class
+          @context.class
+        else
+          # context is a service, so find the model class
+          Object.const_get(consts[0...-1].join('::') + "::Models::#{model_name}")
+        end
       end
 
       #

--- a/runtime/ms_rest/spec/jsonable_spec.rb
+++ b/runtime/ms_rest/spec/jsonable_spec.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+require 'rspec'
+require 'ms_rest'
+
+module MsRest
+
+  module Models
+    class Basic
+      include JSONable
+
+      def initialize
+        @id = 123
+        @name = 'hello world!'
+        @color = 'blue'
+      end
+
+      attr_accessor :id, :name, :color
+
+      def self.mapper
+        {required: false, serialized_name: 'basic', type: { name: 'Composite', class_name: 'Basic', model_properties: {id: {required: false, serialized_name: 'id', type: {name: 'Number'}}, name: {required: false, serialized_name: 'name', type: {name: 'String'}}, color: {required: false, serialized_name: 'color', type: {name: 'String'}}}}}
+      end
+    end
+  end
+
+  describe Models::Basic do
+    let(:variables) { {'id' => 123, 'name' => 'hello world!', 'color' => 'blue'} }
+
+    it 'should serialize a model' do
+      expect(subject.to_json).to eq variables
+    end
+
+    it 'should deserialize a model' do
+      subject.id = 2345
+      new_subject = Models::Basic.new.from_json(subject.to_json)
+      expect(new_subject.id).to eq subject.id
+    end
+
+    it 'should provide a to_s representation in JSON form with all of the model properties' do
+      expect(subject.to_s).to match "#<MsRest::Models::Basic:(.+)> #{variables}"
+    end
+  end
+end


### PR DESCRIPTION
I found it painful to debug output from the lib since the models don't provide much information when called via to_s. This pull request adds to and from json as well as a more robust to_s implementation which includes the json representation of the model.