### PR TITLE
Added SubResource/Resource Hierarchy

### DIFF
--- a/runtime/ms_rest_azure/lib/ms_rest_azure.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure.rb
@@ -12,9 +12,9 @@ require 'ms_rest_azure/azure_service_client.rb'
 require 'ms_rest_azure/cloud_error_data.rb'
 require 'ms_rest_azure/credentials/application_token_provider.rb'
 require 'ms_rest_azure/polling_state.rb'
+require 'ms_rest_azure/sub_resource.rb'
 require 'ms_rest_azure/resource.rb'
 require 'ms_rest_azure/serialization.rb'
-require 'ms_rest_azure/sub_resource.rb'
 require 'ms_rest_azure/version'
 
 module MsRestAzure end

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/resource.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/resource.rb
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-require_relative 'sub_resource'
 
 module MsRestAzure
   #

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/resource.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/resource.rb
@@ -2,14 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
+require_relative 'sub_resource'
+
 module MsRestAzure
   #
   # Class which represents any Azure resource.
   #
-  class Resource
-
-    # @return [String] the id of the resource.
-    attr_accessor :id
+  class Resource < SubResource
 
     # @return [String] the name of the resource.
     attr_accessor :name


### PR DESCRIPTION
Context for this PR:
In the Swagger Files, there will be a definition for "Resource" and "SubResource" (if they are used). These definitions have historically remained same across the services. 

Resource: name, id, type, location, tags
SubResource: id

Now, there are services such as datalakeanalyticslake, datalakeanalyticsservice, recoveryservicesbackup, etc have added additional properties to them (which is valid). For example, Sku has been added to Resources. 

How are we going to handle it? 

Option 1: We could generate the Resource and SubResource classes per service. This is the approach taken by node sdk. This has been discussed and rejected.

Option 2: We could keep the Resource and SubResource classes as such in the runtime. We could generate the similar classes per service only when they diverge from the standard definition. This is the approach taken by this PR. As an additional enhancement, we have established the relation between the SubResource and Resource classes themselves. 

Note: One another suggestion was to rename the class "SubResource" to "Identifiable". This is a valid suggestion. But, this needs additional considerations. Are we going to reflect the namechange in all SDKs? Are we going to use that Identifiable class as parent class for any model that has only the Id property? There may be other questions. I have made a call to not do that in this PR. I have opened a seperate issue #664


Ref #1: https://github.com/Azure/azure-sdk-for-ruby/issues/659
Ref #2: https://github.com/Azure/azure-sdk-for-ruby/issues/647 
Ref #3: Failure of nightly builds

@veronicagg @vishrutshah @salameer Please review.