### PR TITLE
Change the swagger file for generating arm_logic sdk

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -253,10 +253,9 @@ REGEN_METADATA = {
         tag: 'arm_lock'
     },
     azure_mgmt_logic: {
-        spec_uri: 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-logic/CompositeLogicClient.json',
+        spec_uri: 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-logic/2016-06-01/swagger/logic.json',
         ns: 'Azure::ARM::Logic',
         version: version,
-        modeler: "CompositeSwagger",
         tag: 'arm_logic'
     },
     azure_mgmt_machine_learning: {

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -225,11 +225,10 @@
       ]
     },
     "azure_mgmt_logic": {
-      "swagger": "arm-logic/CompositeLogicClient.json",
+      "swagger": "arm-logic/2016-06-01/swagger/logic.json",
       "autorest_options": {
         "Namespace": "Azure::ARM::Logic",
         "PackageName": "azure_mgmt_logic",
-        "Modeler": "CompositeSwagger",
         "PackageVersion": "0.9.0"
       },
       "output_dir": "management/azure_mgmt_logic/lib",


### PR DESCRIPTION
@salameer @vishrutshah @veronicagg @amarzavery @daviburg

In this PR, the swagger file used to generate arm_logic has been changed from the compositeswagger to a single file. This has been done for the following reasons:

1. The [composite swagger file](https://github.com/Azure/azure-rest-api-specs/blob/master/arm-logic/CompositeLogicClient.json) is incorrect. It has 2 versions of the same file (with same paths and definitions). 

2. The .NET SDK generation is based on the single file. Refer the script [here](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/src/ResourceManagement/Logic/Microsoft.Azure.Management.Logic/generate.cmd). The same applies to Go SDK generation also. Waiting for confirmation from Python & Node SDK teams. 

3. If we do use the compositeswagger files, the autorest core will fail the SDK generation process. You can see a sample error message [here](http://azuresdkci.cloudapp.net/job/Azure-sdk-for-ruby-regen-nightly/325/console). 

So, in order to avoid the error and align the Ruby SDK generation process with the .NET SDK, I have changed the file. 

I have include the before and after changes of the SDK at \\saran-dev1\shared\arm_logic You could use windiff to compare. 

Also, I have notified the RP team to remove the compositeswagger file or make suitable changes so it is valid. I will follow up with them seperately. 