### PR TITLE
Code changes to handle nokogiri gem version changes

### DIFF
--- a/azure.gemspec
+++ b/azure.gemspec
@@ -36,7 +36,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
   s.add_runtime_dependency('mime-types',              ['>= 1', '< 4.0'])  # vagrant-share and other stuff relies on 1
-  s.add_runtime_dependency('nokogiri',                '~> 1.6')
+  if RUBY_VERSION.match(/(^1\.9.*)|(^2\.0.*)/)
+    s.add_runtime_dependency('nokogiri',              '~> 1.6.0')
+  else
+    s.add_runtime_dependency('nokogiri',              '~> 1.7')
+  end
   s.add_runtime_dependency('systemu',                 '~> 2.6')
   s.add_runtime_dependency('thor',                    '~> 0.19')
 

--- a/azure.gemspec
+++ b/azure.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
   s.add_runtime_dependency('mime-types',              ['>= 1', '< 4.0'])  # vagrant-share and other stuff relies on 1
-  if RUBY_VERSION.match(/(^1\.9.*)|(^2\.0.*)/)
+  if RUBY_VERSION < "2.1.0"
     s.add_runtime_dependency('nokogiri',              '~> 1.6.0')
   else
     s.add_runtime_dependency('nokogiri',              '~> 1.7')


### PR DESCRIPTION
**Context**
1. 'azure' gem has a dependency on 'nokogiri'. [Dependency Spec: ~>1.6]
2. 'azure' gem must support ruby versions >= 1.9.3 
3. 'nokogiri' has moved to version '1.7' which supports ruby version >= 2.1.0 

**Problem**
Assume a user with ruby version 1.9.3 and using azure gem. While installing the gem, the nokogiri gem version of 1.7 will be attempted to install [since it is compatible to 1.6 - in theory]. But the gem install will fail since nokogiri(1.7) could be installed only on ruby versions >= 2.1.0

**Solution**
We are going to check in the gemspec file for the Ruby version. If the version starts with '1.9'/'2.0' then nokogiri version that is compatible with 1.6.0 could be installed. Else, nokogiri version that is compatible with 1.7 (or greater) could be installed.

**Test**
Built the gem locally and tested with multiple ruby versions. 

@yaxia @seguler @vishrutshah @veronicagg @salameer @devigned Could you please review and approve? 