### PR TITLE
Code changes to fix bug related to provisioning status in Polling State Object

### DIFF
--- a/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
@@ -41,7 +41,7 @@ module MsRestAzure
       polling_state = PollingState.new(azure_response, @long_running_operation_retry_timeout)
       request = azure_response.request
 
-      if !AsyncOperationStatus.is_terminal_status(polling_state.status)
+      while !AsyncOperationStatus.is_terminal_status(polling_state.status)
         task = Concurrent::TimerTask.new do
           begin
             if !polling_state.azure_async_operation_header_link.nil?

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb
@@ -41,7 +41,7 @@ module MsRestAzure
       polling_state = PollingState.new(azure_response, @long_running_operation_retry_timeout)
       request = azure_response.request
 
-      while !AsyncOperationStatus.is_terminal_status(polling_state.status)
+      if !AsyncOperationStatus.is_terminal_status(polling_state.status)
         task = Concurrent::TimerTask.new do
           begin
             if !polling_state.azure_async_operation_header_link.nil?

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/polling_state.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/polling_state.rb
@@ -35,21 +35,35 @@ module MsRestAzure
       update_response(azure_response.response)
       @resource = azure_response.body
 
+      case @response.status
+        when 202
+          @status = AsyncOperationStatus::IN_PROGRESS_STATUS
+        when 200
+          provisioning_state = get_provisioning_state
+          @status = provisioning_state.nil?? (AsyncOperationStatus::SUCCESS_STATUS):provisioning_state
+        when 201
+          provisioning_state = get_provisioning_state
+          @status = provisioning_state.nil?? (AsyncOperationStatus::IN_PROGRESS_STATUS):provisioning_state
+        when 204
+          @status = AsyncOperationStatus::SUCCESS_STATUS
+        else
+          @status = AsyncOperationStatus::FAILED_STATUS
+      end
+    end
+
+    #
+    # Returns the provisioning status of the resource
+    #
+    # @return [String] provisioning status of the resource
+    def get_provisioning_state
       # On non flattened resource, we should find provisioning_state inside 'properties'
       if (!@resource.nil? && @resource.respond_to?(:properties) && @resource.properties.respond_to?(:provisioning_state) && !@resource.properties.provisioning_state.nil?)
-        @status = @resource.properties.provisioning_state
-      # On flattened resource, we should find provisioning_state at the top level
+        @resource.properties.provisioning_state
+        # On flattened resource, we should find provisioning_state at the top level
       elsif !@resource.nil? && @resource.respond_to?(:provisioning_state) && !@resource.provisioning_state.nil?
-        @status = @resource.provisioning_state
+        @resource.provisioning_state
       else
-        case @response.status
-          when 202
-            @status = AsyncOperationStatus::IN_PROGRESS_STATUS
-          when 200, 201, 204
-            @status = AsyncOperationStatus::SUCCESS_STATUS
-          else
-            @status = AsyncOperationStatus::FAILED_STATUS
-          end
+        nil
       end
     end
 

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/polling_state.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/polling_state.rb
@@ -36,14 +36,14 @@ module MsRestAzure
       @resource = azure_response.body
 
       case @response.status
-        when 202
-          @status = AsyncOperationStatus::IN_PROGRESS_STATUS
         when 200
           provisioning_state = get_provisioning_state
           @status = provisioning_state.nil?? (AsyncOperationStatus::SUCCESS_STATUS):provisioning_state
         when 201
           provisioning_state = get_provisioning_state
           @status = provisioning_state.nil?? (AsyncOperationStatus::IN_PROGRESS_STATUS):provisioning_state
+        when 202
+          @status = AsyncOperationStatus::IN_PROGRESS_STATUS
         when 204
           @status = AsyncOperationStatus::SUCCESS_STATUS
         else


### PR DESCRIPTION
Our logic to determine Status in the Polling state object is incorrect. The [Node SDK](https://github.com/Azure/azure-sdk-for-node/blob/0a52678ea7b3a24a478975f7169fc30e9fc9759e/runtime/ms-rest-azure/lib/pollingState.js#L44) and [.NET SDK](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs#L49) are having similar and correct code. 

This PR is to modify our logic to ensure that it aligns with the logic of .NET and Node SDKs. 

Added rspec tests to ms_rest_azure and confirmed they are passing. Also, pointed ms_rest and ms_rest_azure locally and ran the tests in the entire sdk ruby and confirmed that nothing is breaking.

Please review and approve.

Related to https://github.com/Azure/azure-sdk-for-ruby/issues/817