### PR TITLE
Name parameter is required (Data Lake Store Account)

### DIFF
--- a/management/azure_mgmt_datalake_store/lib/generated/azure_mgmt_datalake_store/models/firewall_rule.rb
+++ b/management/azure_mgmt_datalake_store/lib/generated/azure_mgmt_datalake_store/models/firewall_rule.rb
@@ -43,7 +43,7 @@ module Azure::ARM::DataLakeStore
                 }
               },
               name: {
-                required: false,
+                required: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'


### PR DESCRIPTION
Hi,
I am using azure_mgmt_datalake_store. I want to report that in Firewall Rule object, the name parameter is marked as an optional parameter here but it is required. I have made the changes. #900 