### PR TITLE
[MsRestAzure] MSI authentication no longer requires use of TenantID in request

### DIFF
--- a/runtime/ms_rest_azure/CHANGELOG.md
+++ b/runtime/ms_rest_azure/CHANGELOG.md
@@ -1,3 +1,6 @@
+##2017.09.06 ms_rest_azure version 0.8.3
+* Add header `Metadata='true'` for Managed Service Identity authentication to acquire token.[Issue #930](https://github.com/Azure/azure-sdk-for-ruby/issues/930) [PR #889](https://github.com/Azure/azure-sdk-for-ruby/pull/889)
+
 ##2017.08.28 ms_rest_azure version 0.8.2
 * Enable Managed Service Identity authentication features into ms_rest_azure runtime for azure_mgmt_* sdks.[Issue #884](https://github.com/Azure/azure-sdk-for-ruby/issues/884) [PR #889](https://github.com/Azure/azure-sdk-for-ruby/pull/889)
 

--- a/runtime/ms_rest_azure/CHANGELOG.md
+++ b/runtime/ms_rest_azure/CHANGELOG.md
@@ -1,5 +1,5 @@
-##2017.09.06 ms_rest_azure version 0.8.3
-* Add header `Metadata='true'` for Managed Service Identity authentication to acquire token.[Issue #930](https://github.com/Azure/azure-sdk-for-ruby/issues/930) [PR #931](https://github.com/Azure/azure-sdk-for-ruby/pull/931)
+##Unreleased ms_rest_azure version 0.9.0
+* [Breaking Change] Managed Service Identity authentication to acquire token does not require `tenant_id`.[Issue #930](https://github.com/Azure/azure-sdk-for-ruby/issues/930) [PR #931](https://github.com/Azure/azure-sdk-for-ruby/pull/931)
 
 ##2017.08.28 ms_rest_azure version 0.8.2
 * Enable Managed Service Identity authentication features into ms_rest_azure runtime for azure_mgmt_* sdks.[Issue #884](https://github.com/Azure/azure-sdk-for-ruby/issues/884) [PR #889](https://github.com/Azure/azure-sdk-for-ruby/pull/889)
@@ -30,7 +30,7 @@
 * Improved AzureOperationError class to expose error_message and error_code properties [#1450](https://github.com/Azure/autorest/pull/1450)
 
 ##2016.09.15 ms_rest_azure version 0.5.0
-* Updating ms_rest dependecy to version 0.5.0
+* Updating ms_rest dependency to version 0.5.0
 * Adding known Azure Environments in ruby runtime for easy discovery
 * Default Azure active directory url is updated from `https://login.windows.net/` to `https://login.microsoftonline.com/` (Breaking Change)
 * Using bundled default ca-cert from ms_rest

--- a/runtime/ms_rest_azure/CHANGELOG.md
+++ b/runtime/ms_rest_azure/CHANGELOG.md
@@ -1,5 +1,5 @@
 ##2017.09.06 ms_rest_azure version 0.8.3
-* Add header `Metadata='true'` for Managed Service Identity authentication to acquire token.[Issue #930](https://github.com/Azure/azure-sdk-for-ruby/issues/930) [PR #889](https://github.com/Azure/azure-sdk-for-ruby/pull/889)
+* Add header `Metadata='true'` for Managed Service Identity authentication to acquire token.[Issue #930](https://github.com/Azure/azure-sdk-for-ruby/issues/930) [PR #931](https://github.com/Azure/azure-sdk-for-ruby/pull/931)
 
 ##2017.08.28 ms_rest_azure version 0.8.2
 * Enable Managed Service Identity authentication features into ms_rest_azure runtime for azure_mgmt_* sdks.[Issue #884](https://github.com/Azure/azure-sdk-for-ruby/issues/884) [PR #889](https://github.com/Azure/azure-sdk-for-ruby/pull/889)

--- a/runtime/ms_rest_azure/README.md
+++ b/runtime/ms_rest_azure/README.md
@@ -37,16 +37,16 @@ To start working on the gem the only additional dev dependecy is required - rspe
 Reference it in the gemfile and also add this line to your client's gemspec file:
 
 ```ruby
-spec.add_runtime_dependency 'ms_rest_azure', '~> 0.8.3'
+spec.add_runtime_dependency 'ms_rest_azure', '~> 0.9.0'
 ```
 Don't forget to correct the version.
 
 # Utilizing MSI(Managed Service Identity) Token Provider
 
-MSI support has been enabled in `ms_rest_azure` version `0.8.3`. Below code snippet demonstrates how to use MSITokenProvider with default port `50342`:  
+MSI support has been enabled in `ms_rest_azure` version `0.9.0`. Below code snippet demonstrates how to use MSITokenProvider with default port `50342`:  
 
 ```ruby
-provider = MsRestAzure::MSITokenProvider.new('{tenant_id}')
+provider = MsRestAzure::MSITokenProvider.new()
 credentials = MsRest::TokenCredentials.new(provider)
 ```
 

--- a/runtime/ms_rest_azure/README.md
+++ b/runtime/ms_rest_azure/README.md
@@ -37,13 +37,13 @@ To start working on the gem the only additional dev dependecy is required - rspe
 Reference it in the gemfile and also add this line to your client's gemspec file:
 
 ```ruby
-spec.add_runtime_dependency 'ms_rest_azure', '~> 0.8.2'
+spec.add_runtime_dependency 'ms_rest_azure', '~> 0.8.3'
 ```
 Don't forget to correct the version.
 
 # Utilizing MSI(Managed Service Identity) Token Provider
 
-MSI support has been enabled in `ms_rest_azure` version `0.8.2`. Below code snippet demonstrates how to use MSITokenProvider with default port `50342`:  
+MSI support has been enabled in `ms_rest_azure` version `0.8.3`. Below code snippet demonstrates how to use MSITokenProvider with default port `50342`:  
 
 ```ruby
 provider = MsRestAzure::MSITokenProvider.new('{tenant_id}')

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/msi_token_provider.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/msi_token_provider.rb
@@ -11,14 +11,11 @@ module MsRestAzure
     private
 
     TOKEN_ACQUIRE_URL = 'http://localhost:{port}/oauth2/token'
-    REQUEST_BODY_PATTERN = 'authority={authentication_endpoint}{tenant_id}&resource={resource_uri}'
+    REQUEST_BODY_PATTERN = 'resource={resource_uri}'
     DEFAULT_SCHEME = 'Bearer'
 
     # @return [MSIActiveDirectoryServiceSettings] settings.
     attr_accessor :settings
-
-    # @return [String] tenant id (also known as domain).
-    attr_accessor :tenant_id
 
     # @return [Integer] port number where MSI service is running.
     attr_accessor :port
@@ -39,16 +36,13 @@ module MsRestAzure
 
     #
     # Creates and initialize new instance of the MSITokenProvider class.
-    # @param tenant_id [String] tenant id (also known as domain).
     # @param port [Integer] port number where MSI service is running.
     # @param settings [ActiveDirectoryServiceSettings] active directory setting.
-    def initialize(tenant_id, port = 50342, settings = ActiveDirectoryServiceSettings.get_azure_settings)
-      fail ArgumentError, 'Tenant id cannot be nil' if tenant_id.nil?
+    def initialize(port = 50342, settings = ActiveDirectoryServiceSettings.get_azure_settings)
       fail ArgumentError, 'Port cannot be nil' if port.nil?
       fail ArgumentError, 'Port must be an Integer' unless port.is_a? Integer
       fail ArgumentError, 'Azure AD settings cannot be nil' if settings.nil?
 
-      @tenant_id = tenant_id
       @port = port
       @settings = settings
 
@@ -90,8 +84,6 @@ module MsRestAzure
       end
 
       request_body = REQUEST_BODY_PATTERN.dup
-      request_body['{authentication_endpoint}'] = ERB::Util.url_encode(@settings.authentication_endpoint)
-      request_body['{tenant_id}'] = ERB::Util.url_encode(@tenant_id)
       request_body['{resource_uri}'] = ERB::Util.url_encode(@settings.token_audience)
 
       response = connection.post do |request|

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/msi_token_provider.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/msi_token_provider.rb
@@ -96,6 +96,7 @@ module MsRestAzure
 
       response = connection.post do |request|
         request.headers['content-type'] = 'application/x-www-form-urlencoded'
+        request.headers['Metadata'] = 'true'
         request.body = request_body
       end
 

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/version.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/version.rb
@@ -3,5 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 module MsRestAzure
-  VERSION = '0.8.2'
+  VERSION = '0.8.3'
 end

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/version.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/version.rb
@@ -3,5 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 module MsRestAzure
-  VERSION = '0.8.3'
+  VERSION = '0.9.0'
 end

--- a/runtime/ms_rest_azure/spec/msi_token_provider_spec.rb
+++ b/runtime/ms_rest_azure/spec/msi_token_provider_spec.rb
@@ -10,17 +10,13 @@ module MsRestAzure
   describe MSITokenProvider do
     it 'should throw error if nil data is passed into constructor' do
       expect { MSITokenProvider.new(nil) }.to raise_error(ArgumentError)
-      expect { MSITokenProvider.new('tenant_id',nil) }.to raise_error(ArgumentError)
-      expect { MSITokenProvider.new('tenant_id','port') }.to raise_error(ArgumentError)
-      expect { MSITokenProvider.new('tenant_id',50431,nil) }.to raise_error(ArgumentError)
+      expect { MSITokenProvider.new(50431,nil) }.to raise_error(ArgumentError)
     end
 
     it 'should set defaults for managed service identity' do
-      tenant = 'xxxx-xxxx-xxxxx-xxxxx'
       azure_cloud = MsRestAzure::AzureEnvironments::AzureCloud
 
-      token_provider = MSITokenProvider.new(tenant)
-      expect(token_provider.send(:tenant_id)).to eq(tenant)
+      token_provider = MSITokenProvider.new
       expect(token_provider.send(:port)).to eq(50342)
       settings = token_provider.send(:settings)
       expect(settings.authentication_endpoint).to eq(azure_cloud.active_directory_endpoint_url)
@@ -28,14 +24,12 @@ module MsRestAzure
     end
 
     it 'should set customs for managed service identity' do
-      tenant = 'xxxx-xxxx-xxxxx-xxxxx'
       port = 50333
       settings = ActiveDirectoryServiceSettings.new()
       settings.authentication_endpoint = 'https://login.microsoftonline.com/'
       settings.token_audience = 'https://vault.azure.net'
 
-      token_provider = MSITokenProvider.new(tenant, port, settings)
-      expect(token_provider.send(:tenant_id)).to eq(tenant)
+      token_provider = MSITokenProvider.new(port, settings)
       expect(token_provider.send(:port)).to eq(port)
       settings = token_provider.send(:settings)
       expect(settings.authentication_endpoint).to eq(settings.authentication_endpoint)


### PR DESCRIPTION
Addresses #930 

- [x] Verify with latest VM + MSI deployments on 09/06