### PR TITLE
Revert "[rake arm:release] Rescue error while publishing (#972)"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,12 +45,8 @@ namespace :arm do
   desc 'Push gem for each of the Azure Resource Manager projects'
   task :release, [:key] => :build do |_, args|
     each_gem do |dir|
-      begin
-        # Using execute method so that keys are not logged onto console
-        execute("gem push ./pkg/#{dir}-#{version}.gem" + (args[:key].nil? ? '' : " -k #{args[:key]}"))
-      rescue Exception => ex
-        puts "Error occurred while publishing #{dir}: #{ex}"
-      end
+      # Using execute method so that keys are not logged onto console
+      execute("gem push ./pkg/#{dir}-#{version}.gem" + (args[:key].nil? ? '' : " -k #{args[:key]}"))
     end
   end
 


### PR DESCRIPTION
This reverts commit 59eeea598daf1868637ef979fab8bef33534d49d.

The reason we added this change was to make sure even one of the gem publish fails we can still try releasing other gems. This was a temporary change but once we have publishing story for individual gem we'll be able to better control how we release an each gem. 

cc: @sarangan12 Let's talk about this in case you were working on release story task :)