### PR TITLE
Updating bundler version for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.1.5
   - 2.2.0
   - 2.3.0
-before_install: gem install bundler -v 1.14.1
 matrix:
   include:
     - rvm: 2.3.0
@@ -13,6 +12,7 @@ matrix:
     - rvm: 2.3.0
       env: LATEST_RUNTIME=true
 before_install:
+  - gem install bundler -v 1.14.1
   - if [ "$LATEST_RUNTIME" == "true" ] ; then ./scripts/latest_runtime.sh ; fi
 script:
   - if [ "$INTEG_RECORDED" == "true" ] ; then bundle install --gemfile=Gemfile && bundle exec rake arm:spec ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.5
   - 2.2.0
   - 2.3.0
+before_install: gem install bundler -v 1.14.1
 matrix:
   include:
     - rvm: 2.3.0
@@ -14,7 +15,6 @@ matrix:
 before_install:
   - if [ "$LATEST_RUNTIME" == "true" ] ; then ./scripts/latest_runtime.sh ; fi
 script:
-  - gem install bundler
   - if [ "$INTEG_RECORDED" == "true" ] ; then bundle install --gemfile=Gemfile && bundle exec rake arm:spec ; fi
   - bundle exec rake arm:build
   - unset BUNDLE_GEMFILE


### PR DESCRIPTION
CI is failing for PR https://github.com/Azure/azure-sdk-for-ruby/pull/925 for older ruby versions, it appears that travis is running with older versions of bundler. 
Older version is running with 1.8 version and we need fix https://github.com/bundler/bundler/commit/f4481a7e3dbaf7f563e32afbe2cbbb84e3091f16 which was included starting 1.10.

Making bundler version update same as https://github.com/Azure/azure-ruby-asm-core/blob/master/.travis.yml#L8 
