### PR TITLE
[Azure Stack] Enable swagger to sdk for multi-api version

### DIFF
--- a/management/azure_mgmt_analysis_services/azure_mgmt_analysis_services.gemspec
+++ b/management/azure_mgmt_analysis_services/azure_mgmt_analysis_services.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
+++ b/management/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_automation/azure_mgmt_automation.gemspec
+++ b/management/azure_mgmt_automation/azure_mgmt_automation.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_batch/azure_mgmt_batch.gemspec
+++ b/management/azure_mgmt_batch/azure_mgmt_batch.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_billing/azure_mgmt_billing.gemspec
+++ b/management/azure_mgmt_billing/azure_mgmt_billing.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
+++ b/management/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
+++ b/management/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
+++ b/management/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_compute/azure_mgmt_compute.gemspec
+++ b/management/azure_mgmt_compute/azure_mgmt_compute.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_consumption/azure_mgmt_consumption.gemspec
+++ b/management/azure_mgmt_consumption/azure_mgmt_consumption.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_container_instance/azure_mgmt_container_instance.gemspec
+++ b/management/azure_mgmt_container_instance/azure_mgmt_container_instance.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_container_registry/azure_mgmt_container_registry.gemspec
+++ b/management/azure_mgmt_container_registry/azure_mgmt_container_registry.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_container_service/azure_mgmt_container_service.gemspec
+++ b/management/azure_mgmt_container_service/azure_mgmt_container_service.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_customer_insights/azure_mgmt_customer_insights.gemspec
+++ b/management/azure_mgmt_customer_insights/azure_mgmt_customer_insights.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
+++ b/management/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
+++ b/management/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
+++ b/management/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_dns/azure_mgmt_dns.gemspec
+++ b/management/azure_mgmt_dns/azure_mgmt_dns.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_event_grid/azure_mgmt_event_grid.gemspec
+++ b/management/azure_mgmt_event_grid/azure_mgmt_event_grid.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_event_hub/azure_mgmt_event_hub.gemspec
+++ b/management/azure_mgmt_event_hub/azure_mgmt_event_hub.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_features/azure_mgmt_features.gemspec
+++ b/management/azure_mgmt_features/azure_mgmt_features.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_graph/azure_mgmt_graph.gemspec
+++ b/management/azure_mgmt_graph/azure_mgmt_graph.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_insights/azure_mgmt_insights.gemspec
+++ b/management/azure_mgmt_insights/azure_mgmt_insights.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
+++ b/management/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
+++ b/management/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_links/azure_mgmt_links.gemspec
+++ b/management/azure_mgmt_links/azure_mgmt_links.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_locks/azure_mgmt_locks.gemspec
+++ b/management/azure_mgmt_locks/azure_mgmt_locks.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_logic/azure_mgmt_logic.gemspec
+++ b/management/azure_mgmt_logic/azure_mgmt_logic.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
+++ b/management/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_managed_applications/azure_mgmt_managed_applications.gemspec
+++ b/management/azure_mgmt_managed_applications/azure_mgmt_managed_applications.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_marketplace_ordering/azure_mgmt_marketplace_ordering.gemspec
+++ b/management/azure_mgmt_marketplace_ordering/azure_mgmt_marketplace_ordering.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
+++ b/management/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_mobile_engagement/azure_mgmt_mobile_engagement.gemspec
+++ b/management/azure_mgmt_mobile_engagement/azure_mgmt_mobile_engagement.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_monitor/azure_mgmt_monitor.gemspec
+++ b/management/azure_mgmt_monitor/azure_mgmt_monitor.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_network/azure_mgmt_network.gemspec
+++ b/management/azure_mgmt_network/azure_mgmt_network.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
+++ b/management/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_operational_insights/azure_mgmt_operational_insights.gemspec
+++ b/management/azure_mgmt_operational_insights/azure_mgmt_operational_insights.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_policy/azure_mgmt_policy.gemspec
+++ b/management/azure_mgmt_policy/azure_mgmt_policy.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
+++ b/management/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_recovery_services/azure_mgmt_recovery_services.gemspec
+++ b/management/azure_mgmt_recovery_services/azure_mgmt_recovery_services.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_recovery_services_backup/azure_mgmt_recovery_services_backup.gemspec
+++ b/management/azure_mgmt_recovery_services_backup/azure_mgmt_recovery_services_backup.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_recovery_services_site_recovery/azure_mgmt_recovery_services_site_recovery.gemspec
+++ b/management/azure_mgmt_recovery_services_site_recovery/azure_mgmt_recovery_services_site_recovery.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_redis/azure_mgmt_redis.gemspec
+++ b/management/azure_mgmt_redis/azure_mgmt_redis.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_relay/azure_mgmt_relay.gemspec
+++ b/management/azure_mgmt_relay/azure_mgmt_relay.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
+++ b/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_resources_management/azure_mgmt_resources_management.gemspec
+++ b/management/azure_mgmt_resources_management/azure_mgmt_resources_management.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
+++ b/management/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_search/azure_mgmt_search.gemspec
+++ b/management/azure_mgmt_search/azure_mgmt_search.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_server_management/azure_mgmt_server_management.gemspec
+++ b/management/azure_mgmt_server_management/azure_mgmt_server_management.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
+++ b/management/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_service_fabric/azure_mgmt_service_fabric.gemspec
+++ b/management/azure_mgmt_service_fabric/azure_mgmt_service_fabric.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_sql/azure_mgmt_sql.gemspec
+++ b/management/azure_mgmt_sql/azure_mgmt_sql.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_stor_simple8000_series/azure_mgmt_stor_simple8000_series.gemspec
+++ b/management/azure_mgmt_stor_simple8000_series/azure_mgmt_stor_simple8000_series.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_storage/azure_mgmt_storage.gemspec
+++ b/management/azure_mgmt_storage/azure_mgmt_storage.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_stream_analytics/azure_mgmt_stream_analytics.gemspec
+++ b/management/azure_mgmt_stream_analytics/azure_mgmt_stream_analytics.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
+++ b/management/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
+++ b/management/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/management/azure_mgmt_web/azure_mgmt_web.gemspec
+++ b/management/azure_mgmt_web/azure_mgmt_web.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*"]
+  spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -5,10 +5,7 @@
     "autorest": "latest",
     "autorest_options": {
       "ruby": "",
-      "azure-arm": true,
-      "use": "/autorest.ruby",
-      "debug": "",
-      "verbose": ""
+      "azure-arm": true
     }
   },
   "projects": {
@@ -16,7 +13,7 @@
       "markdown": "specification/analysisservices/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::AnalysisServices::Api_2017_07_14",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_analysis_services",
         "tag": "package-2017-07"
       },
@@ -28,7 +25,7 @@
       "markdown": "specification/analysisservices/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::AnalysisServices::Api_2016_05_16",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_analysis_services",
         "tag": "package-2016-05"
       },
@@ -40,7 +37,7 @@
       "markdown": "specification/authorization/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Authorization::Api_2015_07_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_authorization",
         "tag": "package-2015-07"
       },
@@ -49,22 +46,22 @@
       "build_dir": "management/azure_mgmt_authorization/lib/2015-07-01"
     },
     "azure_mgmt_automation_2015_10_31": {
-      "markdown": "specification/authorization/resource-manager/readme.md",
+      "markdown": "specification/automation/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Authorization::Api_2015_10_31",
-        "package-version": "0.11.0",
-        "package-name": "azure_mgmt_authorization",
+        "namespace": "Azure::ARM::Automation::Api_2015_10_31",
+        "package-version": "0.14.0",
+        "package-name": "azure_mgmt_automation",
         "tag": "package-2015-10"
       },
-      "output_dir": "management/azure_mgmt_authorization/lib/2015-10-31",
+      "output_dir": "management/azure_mgmt_automation/lib/2015-10-31",
       "generated_relative_base_directory": "2015-10-31",
-      "build_dir": "management/azure_mgmt_authorization/lib/2015-10-31"
+      "build_dir": "management/azure_mgmt_automation/lib/2015-10-31"
     },
     "azure_mgmt_batch_2017_05_01": {
       "markdown": "specification/batch/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Batch::Api_2017_05_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_batch",
         "tag": "package-2017-05"
       },
@@ -76,7 +73,7 @@
       "markdown": "specification/batch/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Batch::Api_2015_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_batch",
         "tag": "package-2015-12"
       },
@@ -88,7 +85,7 @@
       "markdown": "specification/billing/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Billing::Api_2017_04_24_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_billing",
         "tag": "package-2017-04-preview"
       },
@@ -100,7 +97,7 @@
       "markdown": "specification/cdn/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::CDN::Api_2017_04_02",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_cdn",
         "tag": "package-2017-04"
       },
@@ -112,7 +109,7 @@
       "markdown": "specification/cdn/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::CDN::Api_2016_10_02",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_cdn",
         "tag": "package-2016-10"
       },
@@ -124,7 +121,7 @@
       "markdown": "specification/cdn/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::CDN::Api_2015_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_cdn",
         "tag": "package-2015-06"
       },
@@ -136,7 +133,7 @@
       "markdown": "specification/cognitiveservices/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::CognitiveServices::Api_2017_04_18",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_cognitive_services",
         "tag": "package-2017-04"
       },
@@ -148,18 +145,18 @@
       "markdown": "specification/commerce/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Commerce::Api_2015_06_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_commerce",
         "tag": "package-2015-06-preview"
       },
-      "output_dir": "management/azure_mgmt_cognitive_services/lib/2015-06-01-preview",
-      "generated_relative_base_directory": "2017-04-18",
-      "build_dir": "management/azure_mgmt_cognitive_services/lib/2015-06-01-preview"
+      "output_dir": "management/azure_mgmt_commerce/lib/2015-06-01-preview",
+      "generated_relative_base_directory": "2015-06-01-preview",
+      "build_dir": "management/azure_mgmt_commerce/lib/2015-06-01-preview"
     },
     "azure_mgmt_compute_2017_03_30": {
       "autorest_options": {
         "namespace": "Azure::ARM::Compute::Api_2017_03_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_compute",
         "input-file": [
           "specification/compute/resource-manager/Microsoft.Compute/2017-03-30/compute.json",
@@ -176,7 +173,7 @@
       "markdown": "specification/compute/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Compute::Api_2016_04_30_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_compute",
         "tag": "package-compute-2016-04-preview"
       },
@@ -188,7 +185,7 @@
       "markdown": "specification/compute/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Compute::Api_2016_03_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_compute",
         "tag": "package-compute-2016-03"
       },
@@ -200,7 +197,7 @@
       "markdown": "specification/compute/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Compute::Api_2015_06_15",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_compute",
         "tag": "package-compute-2015-06"
       },
@@ -212,7 +209,7 @@
       "markdown": "specification/consumption/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Consumption::Api_2017_04_24_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_consumption",
         "tag": "package-2017-04-preview"
       },
@@ -224,7 +221,7 @@
       "markdown": "specification/containerinstance/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerInstance::Api_2017_08_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_instance",
         "tag": "package-2017-08-preview"
       },
@@ -236,7 +233,7 @@
       "markdown": "specification/containerregistry/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerRegistry::Api_2017_10_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_registry",
         "tag": "package-2017-10"
       },
@@ -248,7 +245,7 @@
       "markdown": "specification/containerregistry/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerRegistry::Api_2017_06_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_registry",
         "tag": "package-2017-06-preview"
       },
@@ -260,7 +257,7 @@
       "markdown": "specification/containerregistry/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerRegistry::Api_2017_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_registry",
         "tag": "package-2017-03"
       },
@@ -272,7 +269,7 @@
       "markdown": "specification/containerregistry/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerRegistry::Api_2016_06_27_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_registry",
         "tag": "package-2016-06-preview"
       },
@@ -284,7 +281,7 @@
       "markdown": "specification/compute/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerService::Api_2017_01_31",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_service",
         "tag": "package-container-service-2017-01"
       },
@@ -295,7 +292,7 @@
     "azure_mgmt_container_service_2016_09_30": {
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerService::Api_2016_09_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_service",
         "input-file": [
           "specification/compute/resource-manager/Microsoft.ContainerService/2016-09-30/containerService.json"
@@ -308,7 +305,7 @@
     "azure_mgmt_container_service_2016_03_30": {
       "autorest_options": {
         "namespace": "Azure::ARM::ContainerService::Api_2016_03_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_container_service",
         "input-file": [
           "specification/compute/resource-manager/Microsoft.ContainerService/2016-03-30/containerService.json"
@@ -322,7 +319,7 @@
       "markdown": "specification/customer-insights/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::CustomerInsights::Api_2017_04_26",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_customer_insights",
         "tag": "package-2017-04"
       },
@@ -334,19 +331,19 @@
       "markdown": "specification/datalake-analytics/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::DataLakeAnalytics::Api_2016_11_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_datalake_analytics",
         "tag": "package-2016-11"
       },
-      "output_dir": "management/azure_mgmt_datalake_analytics/lib/2017-04-26",
-      "generated_relative_base_directory": "2017-04-26",
-      "build_dir": "management/azure_mgmt_datalake_analytics/lib/2017-04-26"
+      "output_dir": "management/azure_mgmt_datalake_analytics/lib/2016-11-01",
+      "generated_relative_base_directory": "2016-11-01",
+      "build_dir": "management/azure_mgmt_datalake_analytics/lib/2016-11-01"
     },
     "azure_mgmt_datalake_analytics_2015_10_01_preview": {
       "markdown": "specification/datalake-analytics/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::DataLakeAnalytics::Api_2015_10_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_datalake_analytics",
         "tag": "package-2015-10-preview"
       },
@@ -358,7 +355,7 @@
       "markdown": "specification/datalake-store/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::DataLakeStore::Api_2016_11_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_datalake_store",
         "tag": "package-2016-11"
       },
@@ -370,7 +367,7 @@
       "markdown": "specification/datalake-store/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::DataLakeStore::Api_2015_10_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_datalake_store",
         "tag": "package-2015-10-preview"
       },
@@ -378,11 +375,23 @@
       "generated_relative_base_directory": "2015-10-01-preview",
       "build_dir": "management/azure_mgmt_datalake_store/lib/2015-10-01-preview"
     },
+    "azure_mgmt_devtestlabs_2016_05_15": {
+      "markdown": "specification/devtestlabs/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::DevTestLabs::Api_2016_05_15",
+        "package-version": "0.14.0",
+        "package-name": "azure_mgmt_devtestlabs",
+        "tag": "package-2016-05"
+      },
+      "output_dir": "management/azure_mgmt_devtestlabs/lib/2016-05-15",
+      "generated_relative_base_directory": "2016-05-15",
+      "build_dir": "management/azure_mgmt_devtestlabs/lib/2016-05-15"
+    },
     "azure_mgmt_dns_2016_04_01": {
       "markdown": "specification/dns/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Dns::Api_2016_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_dns",
         "tag": "package-2016-04"
       },
@@ -394,7 +403,7 @@
       "markdown": "specification/eventgrid/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::EventGrid::Api_2017_09_15_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_event_grid",
         "tag": "package-2017-09-preview"
       },
@@ -406,7 +415,7 @@
       "markdown": "specification/eventgrid/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::EventGrid::Api_2017_06_15_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_event_grid",
         "tag": "package-2017-06-preview"
       },
@@ -418,7 +427,7 @@
       "markdown": "specification/eventhub/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::EventHub::Api_2017_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_event_hub",
         "tag": "package-2017-04"
       },
@@ -430,7 +439,7 @@
       "markdown": "specification/eventhub/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::EventHub::Api_2015_08_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_event_hub",
         "tag": "package-2015-08"
       },
@@ -442,7 +451,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Features::Api_2015_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_features",
         "tag": "package-features-2015-12"
       },
@@ -453,7 +462,7 @@
     "azure_mgmt_graph_1.6": {
       "autorest_options": {
         "namespace": "Azure::ARM::Graph::Api_1_6",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_graph",
         "input-file": [
           "specification/graphrbac/data-plane/1.6/graphrbac.json"
@@ -467,7 +476,7 @@
       "markdown": "specification/iothub/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::IotHub::Api_2017_07_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_iot_hub",
         "tag": "package-2017-07"
       },
@@ -479,7 +488,7 @@
       "markdown": "specification/iothub/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::IotHub::Api_2017_01_19",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_iot_hub",
         "tag": "package-2017-01"
       },
@@ -491,7 +500,7 @@
       "markdown": "specification/iothub/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::IotHub::Api_2016_02_03",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_iot_hub",
         "tag": "package-2016-02"
       },
@@ -500,10 +509,10 @@
       "build_dir": "management/azure_mgmt_iot_hub/lib/2016-02-03"
     },
     "azure_mgmt_key_vault_2016_10_01": {
-      "markdown": "specification/iothub/resource-manager/readme.md",
+      "markdown": "specification/keyvault/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::KeyVault::Api_2016_10_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_key_vault",
         "tag": "package-2016-10"
       },
@@ -512,10 +521,10 @@
       "build_dir": "management/azure_mgmt_key_vault/lib/2016-10-01"
     },
     "azure_mgmt_key_vault_2015_06_01": {
-      "markdown": "specification/iothub/resource-manager/readme.md",
+      "markdown": "specification/keyvault/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::KeyVault::Api_2015_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_key_vault",
         "tag": "package-2015-06"
       },
@@ -527,20 +536,19 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Links::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_links",
-        "tag": "package-links-2016-09",
-        "title": "LinksManagementClient"
+        "tag": "package-links-2016-09"
       },
-      "output_dir": "management/azure_mgmt_links/lib/2015-06-01",
-      "generated_relative_base_directory": "2015-06-01",
-      "build_dir": "management/azure_mgmt_links/lib/2015-06-01"
+      "output_dir": "management/azure_mgmt_links/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_links/lib/2016-09-01"
     },
     "azure_mgmt_locks_2016_09_01": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Locks::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_locks",
         "tag": "package-locks-2016-09"
       },
@@ -552,7 +560,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Locks::Api_2015_01_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_locks",
         "tag": "package-locks-2015-01"
       },
@@ -564,7 +572,7 @@
       "markdown": "specification/logic/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Logic::Api_2016_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_logic",
         "tag": "package-2016-06"
       },
@@ -576,7 +584,7 @@
       "markdown": "specification/logic/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Logic::Api_2015_02_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_logic",
         "tag": "package-2015-02-preview"
       },
@@ -588,7 +596,7 @@
       "markdown": "specification/machinelearning/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::MachineLearning::Api_2017_01_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_machine_learning",
         "tag": "package-webservices-2017-01"
       },
@@ -600,7 +608,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ManagedApplications::Api_2016_09_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_managed_applications",
         "tag": "package-managedapplications-2016-09"
       },
@@ -612,7 +620,7 @@
       "markdown": "specification/marketplaceordering/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::MarketplaceOrdering::Api_2015_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_marketplace_ordering",
         "tag": "package-2015-06-01"
       },
@@ -624,7 +632,7 @@
       "markdown": "specification/mediaservices/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::MediaServices::Api_2015_10_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_media_services",
         "tag": "package-2015-10"
       },
@@ -636,7 +644,7 @@
       "markdown": "specification/mobileengagement/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::MobileEngagement::Api_2014_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_mobile_engagement",
         "tag": "package-2014-12"
       },
@@ -647,7 +655,7 @@
     "azure_mgmt_monitor_2017_05_01_preview": {
       "autorest_options": {
         "namespace": "Azure::ARM::MobileEngagement::Api_2014_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_monitor",
         "input-file": [
           "specification/monitor/resource-manager/microsoft.insights/2017-05-01-preview/diagnosticsSettingsCategories_API.json",
@@ -662,7 +670,7 @@
     "azure_mgmt_monitor_2017_04_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Monitor::Api_2017_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_monitor",
         "input-file": [
           "specification/monitor/resource-manager/microsoft.insights/2017-04-01/actionGroups_API.json",
@@ -677,7 +685,7 @@
     "azure_mgmt_monitor_2016_09_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Monitor::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_monitor",
         "input-file": [
           "specification/monitor/resource-manager/microsoft.insights/2016-09-01/serviceDiagnosticsSettings_API.json"
@@ -691,7 +699,7 @@
     "azure_mgmt_monitor_2016_03_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Monitor::Api_2016_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_monitor",
         "input-file": [
           "specification/monitor/resource-manager/microsoft.insights/2016-03-01/alertRulesIncidents_API.json",
@@ -707,7 +715,7 @@
     "azure_mgmt_monitor_2015_04_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Monitor::Api_2015_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_monitor",
         "input-file": [
           "specification/monitor/resource-manager/microsoft.insights/2015-04-01/autoscale_API.json",
@@ -722,7 +730,7 @@
     "azure_mgmt_network_2017_09_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2017_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "input-file": [
           "specification/network/resource-manager/Microsoft.Network/2017-09-01/applicationGateway.json",
@@ -751,7 +759,7 @@
     "azure_mgmt_network_2017_03_30": {
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2017_03_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "input-file": [
           "specification/network/resource-manager/Microsoft.Network/2017-09-01/vmssNetworkInterface.json",
@@ -765,7 +773,7 @@
     "azure_mgmt_network_2017_03_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2017_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "input-file": [
           "specification/network/resource-manager/Microsoft.Network/2017-03-01/applicationGateway.json",
@@ -793,7 +801,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2016_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2016-12"
       },
@@ -805,7 +813,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2016-09"
       },
@@ -817,7 +825,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2016_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2016-06"
       },
@@ -829,7 +837,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2016_03_30",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2016-03"
       },
@@ -841,7 +849,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2015_06_15",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2015-06split"
       },
@@ -853,7 +861,7 @@
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Network::Api_2015_05_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_network",
         "tag": "package-2015-05-preview"
       },
@@ -865,7 +873,7 @@
       "markdown": "specification/notificationhubs/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::NotificationHubs::Api_2017_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_notification_hubs",
         "tag": "package-2017-04"
       },
@@ -876,7 +884,7 @@
     "azure_mgmt_operational_insights_2015_11_01_preview": {
       "autorest_options": {
         "namespace": "Azure::ARM::OperationalInsights::Api_2015_11_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_operational_insights",
         "input-file": [
           "specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/2015-11-01-preview/OperationalInsights.json"
@@ -890,7 +898,7 @@
       "markdown": "specification/operationalinsights/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::OperationalInsights::Api_2015_03_20",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_operational_insights",
         "tag": "package-2015-03"
       },
@@ -901,7 +909,7 @@
     "azure_mgmt_policy_2017_06_01_preview": {
       "autorest_options": {
         "namespace": "Azure::ARM::Policy::Api_2017_06_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_policy",
         "input-file": [
           "specification/resources/resource-manager/Microsoft.Authorization/2017-06-01-preview/policyAssignments.json",
@@ -917,7 +925,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Policy::Api_2016_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_policy",
         "tag": "package-policy-2016-12"
       },
@@ -929,7 +937,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Policy::Api_2016_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_policy",
         "tag": "package-policy-2016-04"
       },
@@ -941,7 +949,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Policy::Api_2015_10_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_policy",
         "tag": "package-policy-2015-10"
       },
@@ -953,7 +961,7 @@
       "markdown": "specification/powerbiembedded/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::PowerBiEmbedded::Api_2016_01_29",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_powerbi_embedded",
         "tag": "package-2016-01"
       },
@@ -964,7 +972,7 @@
     "azure_mgmt_recovery_services_2016_12_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServices::Api_2016_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services",
         "input-file": [
           "specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/2016-12-01/backup.json"
@@ -978,7 +986,7 @@
       "markdown": "specification/recoveryservices/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServices::Api_2016_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services",
         "tag": "package-2016-06"
       },
@@ -989,7 +997,7 @@
     "azure_mgmt_recovery_services_backup_2017_07_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2017_07_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services_backup",
         "input-file": [
           "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2017-07-01/jobs.json"
@@ -1002,7 +1010,7 @@
     "azure_mgmt_recovery_services_backup_2016_12_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services_backup",
         "input-file": [
           "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2016-12-01/backupManagement.json"
@@ -1015,7 +1023,7 @@
     "azure_mgmt_recovery_services_backup_2016_08_10": {
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_08_10",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services_backup",
         "input-file": [
           "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2016-08-10/operations.json"
@@ -1029,7 +1037,7 @@
       "markdown": "specification/recoveryservicesbackup/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services_backup",
         "tag": "package-2016-06"
       },
@@ -1037,11 +1045,11 @@
       "generated_relative_base_directory": "2016-06-01",
       "build_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-06-01"
     },
-    "azure_mgmt_recovery_services_2016_08_10": {
+    "azure_mgmt_recovery_services_site_recovery_2016_08_10": {
       "markdown": "specification/recoveryservicessiterecovery/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::RecoveryServicesSiteRecovery::Api_2016_08_10",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_recovery_services_site_recovery",
         "tag": "package-2016-08"
       },
@@ -1053,7 +1061,7 @@
       "markdown": "specification/redis/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Redis::Api_2017_02_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_redis",
         "tag": "package-2017-02"
       },
@@ -1065,7 +1073,7 @@
       "markdown": "specification/redis/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Redis::Api_2016_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_redis",
         "tag": "package-2016-04"
       },
@@ -1077,7 +1085,7 @@
       "markdown": "specification/redis/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Redis::Api_2015_08_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_redis",
         "tag": "package-2015-08"
       },
@@ -1089,7 +1097,7 @@
       "markdown": "specification/relay/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Relay::Api_2017_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_relay",
         "tag": "package-2017-04"
       },
@@ -1101,7 +1109,7 @@
       "markdown": "specification/relay/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Relay::Api_2016_07_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_relay",
         "tag": "package-2016-07"
       },
@@ -1112,7 +1120,7 @@
     "azure_mgmt_resources_2017_05_10": {
       "autorest_options": {
         "namespace": "Azure::ARM::Resources::Api_2017_05_10",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_resources",
         "input-file": [
           "specification/resources/resource-manager/Microsoft.Resources/2017-05-10/resources.json"
@@ -1125,7 +1133,7 @@
     "azure_mgmt_resources_2016_09_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Resources::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_resources",
         "input-file": [
           "specification/resources/resource-manager/Microsoft.Resources/2016-09-01/resources.json"
@@ -1138,7 +1146,7 @@
     "azure_mgmt_resources_2016_07_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Resources::Api_2016_07_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_resources",
         "input-file": [
           "specification/resources/resource-manager/Microsoft.Resources/2016-07-01/resources.json"
@@ -1152,7 +1160,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ResourcesManagement::Api_2017_08_31_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_resources_management",
         "tag": "package-management-2017-08"
       },
@@ -1164,19 +1172,19 @@
       "markdown": "specification/scheduler/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Scheduler::Api_2016_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_scheduler",
         "tag": "package-2016-03"
       },
-      "output_dir": "management/azure_mgmt_scheduler/lib/2017-08-31-preview",
-      "generated_relative_base_directory": "2017-08-31-preview",
-      "build_dir": "management/azure_mgmt_scheduler/lib/2017-08-31-preview"
+      "output_dir": "management/azure_mgmt_scheduler/lib/2016-03-01",
+      "generated_relative_base_directory": "2016-03-01",
+      "build_dir": "management/azure_mgmt_scheduler/lib/2016-03-01"
     },
     "azure_mgmt_search_2015_08_19": {
       "markdown": "specification/search/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Search::Api_2015_08_19",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_search",
         "tag": "package-2015-08"
       },
@@ -1188,7 +1196,7 @@
       "markdown": "specification/servermanagement/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ServerManagement::Api_2016_07_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_server_management",
         "tag": "package-2016-07-preview"
       },
@@ -1200,7 +1208,7 @@
       "markdown": "specification/servicebus/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ServiceBus::Api_2017_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_service_bus",
         "tag": "package-2017-04"
       },
@@ -1212,7 +1220,7 @@
       "markdown": "specification/servicebus/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ServiceBus::Api_2015_08_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_service_bus",
         "tag": "package-2015-08"
       },
@@ -1224,7 +1232,7 @@
       "markdown": "specification/servicefabric/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::ServiceFabric::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_service_fabric",
         "tag": "package-2016-09"
       },
@@ -1236,7 +1244,7 @@
       "markdown": "specification/sql/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::SQL::Api_2014_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_sql",
         "tag": "schema-2014-04"
       },
@@ -1248,7 +1256,7 @@
       "markdown": "specification/sql/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::SQL::Api_2015_05_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_sql",
         "tag": "schema-2015-05-preview"
       },
@@ -1259,7 +1267,7 @@
     "azure_mgmt_sql_2017_03_01_preview": {
       "autorest_options": {
         "namespace": "Azure::ARM::SQL::Api_2017_03_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_sql",
         "input-file": [
           "specification/sql/resource-manager/Microsoft.Sql/2017-03-01-preview/cancelOperations.json"
@@ -1273,7 +1281,7 @@
       "markdown": "specification/storsimple8000series/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::StorSimple8000Series::Api_2017_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_stor_simple8000_series",
         "tag": "package-2017-06"
       },
@@ -1285,7 +1293,7 @@
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Storage::Api_2017_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_storage",
         "tag": "package-2017-06"
       },
@@ -1297,7 +1305,7 @@
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Storage::Api_2016_12_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_storage",
         "tag": "package-2016-12"
       },
@@ -1309,7 +1317,7 @@
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Storage::Api_2016_01_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_storage",
         "tag": "package-2016-01"
       },
@@ -1321,7 +1329,7 @@
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Storage::Api_2015_06_15",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_storage",
         "tag": "package-2015-06"
       },
@@ -1333,7 +1341,7 @@
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Storage::Api_2015_05_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_storage",
         "tag": "package-2015-05-preview"
       },
@@ -1345,7 +1353,7 @@
       "markdown": "specification/streamanalytics/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::StreamAnalytics::Api_2016_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_stream_analytics",
         "tag": "package-2016-03"
       },
@@ -1357,7 +1365,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Subscriptions::Api_2016_06_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_subscriptions",
         "tag": "package-subscriptions-2016-06"
       },
@@ -1369,7 +1377,7 @@
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::Subscriptions::Api_2015_11_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_subscriptions",
         "tag": "package-subscriptions-2015-11"
       },
@@ -1381,7 +1389,7 @@
       "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::TrafficManager::Api_2017_09_01_preview",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_traffic_manager",
         "tag": "package-2017-09-preview"
       },
@@ -1393,7 +1401,7 @@
       "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::TrafficManager::Api_2017_05_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_traffic_manager",
         "tag": "package-2017-05"
       },
@@ -1405,7 +1413,7 @@
       "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::TrafficManager::Api_2017_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_traffic_manager",
         "tag": "package-2017-03"
       },
@@ -1417,7 +1425,7 @@
       "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
         "namespace": "Azure::ARM::TrafficManager::Api_2015_11_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_traffic_manager",
         "tag": "package-2015-11"
       },
@@ -1428,7 +1436,7 @@
     "azure_mgmt_web_2015_08_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Web::Api_2015_08_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_web",
         "input-file": [
           "specification/web/resource-manager/Microsoft.CertificateRegistration/2015-08-01/AppServiceCertificateOrders.json"
@@ -1442,7 +1450,7 @@
     "azure_mgmt_web_2015_04_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Web::Api_2015_04_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_web",
         "input-file": [
           "specification/web/resource-manager/Microsoft.DomainRegistration/2015-04-01/Domains.json",
@@ -1457,7 +1465,7 @@
     "azure_mgmt_web_2016_09_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Web::Api_2016_09_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_web",
         "input-file": [
           "specification/web/resource-manager/Microsoft.Web/2016-09-01/AppServiceEnvironments.json",
@@ -1472,7 +1480,7 @@
     "azure_mgmt_web_2016_08_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Web::Api_2016_08_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_web",
         "input-file": [
           "specification/web/resource-manager/Microsoft.Web/2016-08-01/WebApps.json"
@@ -1486,7 +1494,7 @@
     "azure_mgmt_web_2016_03_01": {
       "autorest_options": {
         "namespace": "Azure::ARM::Web::Api_2016_03_01",
-        "package-version": "0.11.0",
+        "package-version": "0.14.0",
         "package-name": "azure_mgmt_web",
         "input-file": [
           "specification/web/resource-manager/Microsoft.Web/2016-03-01/Certificates.json",

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -5,494 +5,1501 @@
     "autorest": "latest",
     "autorest_options": {
       "ruby": "",
-      "azure-arm": true
+      "azure-arm": true,
+      "use": "/autorest.ruby",
+      "debug": "",
+      "verbose": ""
     }
   },
   "projects": {
-    "azure_mgmt_analysis_services": {
+    "azure_mgmt_analysis_services_2017_07_14": {
       "markdown": "specification/analysisservices/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::AnalysisServices",
+        "namespace": "Azure::ARM::AnalysisServices::Api_2017_07_14",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_analysis_services",
-        "package-version": "0.11.0"
+        "tag": "package-2017-07"
       },
-      "output_dir": "management/azure_mgmt_analysis_services/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_analysis_services.rb"
-      ]
+      "output_dir": "management/azure_mgmt_analysis_services/lib/2017-07-14",
+      "generated_relative_base_directory": "2017-07-14",
+      "build_dir": "management/azure_mgmt_analysis_services/lib/2017-07-14"
     },
-    "azure_mgmt_authorization": {
+    "azure_mgmt_analysis_services_2016_05_16": {
+      "markdown": "specification/analysisservices/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::AnalysisServices::Api_2016_05_16",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_analysis_services",
+        "tag": "package-2016-05"
+      },
+      "output_dir": "management/azure_mgmt_analysis_services/lib/2016-05-16",
+      "generated_relative_base_directory": "2016-05-16",
+      "build_dir": "management/azure_mgmt_analysis_services/lib/2016-05-16"
+    },
+    "azure_mgmt_autorization_2015_07_01": {
       "markdown": "specification/authorization/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Authorization",
+        "namespace": "Azure::ARM::Authorization::Api_2015_07_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_authorization",
-        "package-version": "0.11.0"
+        "tag": "package-2015-07"
       },
-      "output_dir": "management/azure_mgmt_authorization/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_authorization.rb"
-      ]
+      "output_dir": "management/azure_mgmt_authorization/lib/2015-07-01",
+      "generated_relative_base_directory": "2015-07-01",
+      "build_dir": "management/azure_mgmt_authorization/lib/2015-07-01"
     },
-    "azure_mgmt_batch": {
+    "azure_mgmt_automation_2015_10_31": {
+      "markdown": "specification/authorization/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Authorization::Api_2015_10_31",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_authorization",
+        "tag": "package-2015-10"
+      },
+      "output_dir": "management/azure_mgmt_authorization/lib/2015-10-31",
+      "generated_relative_base_directory": "2015-10-31",
+      "build_dir": "management/azure_mgmt_authorization/lib/2015-10-31"
+    },
+    "azure_mgmt_batch_2017_05_01": {
       "markdown": "specification/batch/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Batch",
+        "namespace": "Azure::ARM::Batch::Api_2017_05_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_batch",
-        "package-version": "0.11.0"
+        "tag": "package-2017-05"
       },
-      "output_dir": "management/azure_mgmt_batch/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_batch.rb"
-      ]
+      "output_dir": "management/azure_mgmt_batch/lib/2017-05-01",
+      "generated_relative_base_directory": "2017-05-01",
+      "build_dir": "management/azure_mgmt_batch/lib/2017-05-01"
     },
-    "azure_mgmt_cdn": {
+    "azure_mgmt_batch_2015_12_01": {
+      "markdown": "specification/batch/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Batch::Api_2015_12_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_batch",
+        "tag": "package-2015-12"
+      },
+      "output_dir": "management/azure_mgmt_batch/lib/2015-12-01",
+      "generated_relative_base_directory": "2015-12-01",
+      "build_dir": "management/azure_mgmt_batch/lib/2015-12-01"
+    },
+    "azure_mgmt_billing_2017_04_24_preview": {
+      "markdown": "specification/billing/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Billing::Api_2017_04_24_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_billing",
+        "tag": "package-2017-04-preview"
+      },
+      "output_dir": "management/azure_mgmt_billing/lib/2017-04-24-preview",
+      "generated_relative_base_directory": "2017-04-24-preview",
+      "build_dir": "management/azure_mgmt_billing/lib/2017-04-24-preview"
+    },
+    "azure_mgmt_cdn_2017_04_02": {
       "markdown": "specification/cdn/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::CDN",
+        "namespace": "Azure::ARM::CDN::Api_2017_04_02",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_cdn",
-        "package-version": "0.11.0"
+        "tag": "package-2017-04"
       },
-      "output_dir": "management/azure_mgmt_cdn/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_cdn.rb"
-      ]
+      "output_dir": "management/azure_mgmt_cdn/lib/2017-04-02",
+      "generated_relative_base_directory": "2017-04-02",
+      "build_dir": "management/azure_mgmt_cdn/lib/2017-04-02"
     },
-    "azure_mgmt_cognitive_services": {
+    "azure_mgmt_cdn_2016_10_02": {
+      "markdown": "specification/cdn/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::CDN::Api_2016_10_02",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_cdn",
+        "tag": "package-2016-10"
+      },
+      "output_dir": "management/azure_mgmt_cdn/lib/2016-10-02",
+      "generated_relative_base_directory": "2016-10-02",
+      "build_dir": "management/azure_mgmt_cdn/lib/2016-10-02"
+    },
+    "azure_mgmt_cdn_2015_06_01": {
+      "markdown": "specification/cdn/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::CDN::Api_2015_06_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_cdn",
+        "tag": "package-2015-06"
+      },
+      "output_dir": "management/azure_mgmt_cdn/lib/2015-06-01",
+      "generated_relative_base_directory": "2015-06-01",
+      "build_dir": "management/azure_mgmt_cdn/lib/2015-06-01"
+    },
+    "azure_mgmt_cognitive_services_2017_04_18": {
       "markdown": "specification/cognitiveservices/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::CognitiveServices",
+        "namespace": "Azure::ARM::CognitiveServices::Api_2017_04_18",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_cognitive_services",
-        "package-version": "0.11.0"
+        "tag": "package-2017-04"
       },
-      "output_dir": "management/azure_mgmt_cognitive_services/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_cognitive_services.rb"
-      ]
+      "output_dir": "management/azure_mgmt_cognitive_services/lib/2017-04-18",
+      "generated_relative_base_directory": "2017-04-18",
+      "build_dir": "management/azure_mgmt_cognitive_services/lib/2017-04-18"
     },
-    "azure_mgmt_commerce": {
+    "azure_mgmt_commerce_2015_06_01_preview": {
       "markdown": "specification/commerce/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Commerce",
+        "namespace": "Azure::ARM::Commerce::Api_2015_06_01_preview",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_commerce",
-        "package-version": "0.11.0"
+        "tag": "package-2015-06-preview"
       },
-      "output_dir": "management/azure_mgmt_commerce/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_commerce.rb"
-      ]
+      "output_dir": "management/azure_mgmt_cognitive_services/lib/2015-06-01-preview",
+      "generated_relative_base_directory": "2017-04-18",
+      "build_dir": "management/azure_mgmt_cognitive_services/lib/2015-06-01-preview"
     },
-    "azure_mgmt_compute": {
+    "azure_mgmt_compute_2017_03_30": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Compute::Api_2017_03_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_compute",
+        "input-file": [
+          "specification/compute/resource-manager/Microsoft.Compute/2017-03-30/compute.json",
+          "specification/compute/resource-manager/Microsoft.Compute/2017-03-30/disk.json",
+          "specification/compute/resource-manager/Microsoft.Compute/2017-03-30/runCommands.json"
+        ],
+        "title": "ComputeManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_compute/lib/2017-03-30",
+      "generated_relative_base_directory": "2017-03-30",
+      "build_dir": "management/azure_mgmt_compute/lib/2017-03-30"
+    },
+    "azure_mgmt_compute_2016_04_30_preview": {
       "markdown": "specification/compute/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Compute",
+        "namespace": "Azure::ARM::Compute::Api_2016_04_30_preview",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_compute",
-        "package-version": "0.11.0"
+        "tag": "package-compute-2016-04-preview"
       },
-      "output_dir": "management/azure_mgmt_compute/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_compute.rb"
-      ]
+      "output_dir": "management/azure_mgmt_compute/lib/2016-04-30-preview",
+      "generated_relative_base_directory": "2016-04-30-preview",
+      "build_dir": "management/azure_mgmt_compute/lib/2016-04-30-preview"
     },
-    "azure_mgmt_datalake_analytics": {
+    "azure_mgmt_compute_2016_03_30": {
+      "markdown": "specification/compute/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Compute::Api_2016_03_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_compute",
+        "tag": "package-compute-2016-03"
+      },
+      "output_dir": "management/azure_mgmt_compute/lib/2016-03-30",
+      "generated_relative_base_directory": "2016-03-30",
+      "build_dir": "management/azure_mgmt_compute/lib/2016-03-30"
+    },
+    "azure_mgmt_compute_2015_06_15": {
+      "markdown": "specification/compute/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Compute::Api_2015_06_15",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_compute",
+        "tag": "package-compute-2015-06"
+      },
+      "output_dir": "management/azure_mgmt_compute/lib/2015-06-15",
+      "generated_relative_base_directory": "2015-06-15",
+      "build_dir": "management/azure_mgmt_compute/lib/2015-06-15"
+    },
+    "azure_mgmt_consumption_2017_04_24_preview": {
+      "markdown": "specification/consumption/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Consumption::Api_2017_04_24_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_consumption",
+        "tag": "package-2017-04-preview"
+      },
+      "output_dir": "management/azure_mgmt_consumption/lib/2017-04-24-preview",
+      "generated_relative_base_directory": "2017-04-24-preview",
+      "build_dir": "management/azure_mgmt_consumption/lib/2017-04-24-preview"
+    },
+    "azure_mgmt_container_instance_2017_08_01_preview": {
+      "markdown": "specification/containerinstance/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerInstance::Api_2017_08_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_instance",
+        "tag": "package-2017-08-preview"
+      },
+      "output_dir": "management/azure_mgmt_container_instance/lib/2017-08-01-preview",
+      "generated_relative_base_directory": "2017-08-01-preview",
+      "build_dir": "management/azure_mgmt_container_instance/lib/2017-08-01-preview"
+    },
+    "azure_mgmt_container_registry_2017_10_01": {
+      "markdown": "specification/containerregistry/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerRegistry::Api_2017_10_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_registry",
+        "tag": "package-2017-10"
+      },
+      "output_dir": "management/azure_mgmt_container_registry/lib/2017-10-01",
+      "generated_relative_base_directory": "2017-10-01",
+      "build_dir": "management/azure_mgmt_container_registry/lib/2017-10-01"
+    },
+    "azure_mgmt_container_registry_2017_06_01_preview": {
+      "markdown": "specification/containerregistry/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerRegistry::Api_2017_06_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_registry",
+        "tag": "package-2017-06-preview"
+      },
+      "output_dir": "management/azure_mgmt_container_registry/lib/2017-06-01-preview",
+      "generated_relative_base_directory": "2017-06-01-preview",
+      "build_dir": "management/azure_mgmt_container_registry/lib/2017-06-01-preview"
+    },
+    "azure_mgmt_container_registry_2017_03_01": {
+      "markdown": "specification/containerregistry/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerRegistry::Api_2017_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_registry",
+        "tag": "package-2017-03"
+      },
+      "output_dir": "management/azure_mgmt_container_registry/lib/2017-03-01",
+      "generated_relative_base_directory": "2017-03-01",
+      "build_dir": "management/azure_mgmt_container_registry/lib/2017-03-01"
+    },
+    "azure_mgmt_container_registry_2016_06_27_preview": {
+      "markdown": "specification/containerregistry/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerRegistry::Api_2016_06_27_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_registry",
+        "tag": "package-2016-06-preview"
+      },
+      "output_dir": "management/azure_mgmt_container_registry/lib/2016-06-27-preview",
+      "generated_relative_base_directory": "2016-06-27-preview",
+      "build_dir": "management/azure_mgmt_container_registry/lib/2016-06-27-preview"
+    },
+    "azure_mgmt_container_service_2017_01_31": {
+      "markdown": "specification/compute/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerService::Api_2017_01_31",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_service",
+        "tag": "package-container-service-2017-01"
+      },
+      "output_dir": "management/azure_mgmt_container_service/lib/2017-01-31",
+      "generated_relative_base_directory": "2017-01-31",
+      "build_dir": "management/azure_mgmt_container_service/lib/2017-01-31"
+    },
+    "azure_mgmt_container_service_2016_09_30": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerService::Api_2016_09_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_service",
+        "input-file": [
+          "specification/compute/resource-manager/Microsoft.ContainerService/2016-09-30/containerService.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_container_service/lib/2016-09-30",
+      "generated_relative_base_directory": "2016-09-30",
+      "build_dir": "management/azure_mgmt_container_service/lib/2016-09-30"
+    },
+    "azure_mgmt_container_service_2016_03_30": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::ContainerService::Api_2016_03_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_container_service",
+        "input-file": [
+          "specification/compute/resource-manager/Microsoft.ContainerService/2016-03-30/containerService.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_container_service/lib/2016-03-30",
+      "generated_relative_base_directory": "2016-03-30",
+      "build_dir": "management/azure_mgmt_container_service/lib/2016-03-30"
+    },
+    "azure_mgmt_customer_insights_2017_04_26": {
+      "markdown": "specification/customer-insights/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::CustomerInsights::Api_2017_04_26",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_customer_insights",
+        "tag": "package-2017-04"
+      },
+      "output_dir": "management/azure_mgmt_customer_insights/lib/2017-04-26",
+      "generated_relative_base_directory": "2017-04-26",
+      "build_dir": "management/azure_mgmt_customer_insights/lib/2017-04-26"
+    },
+    "azure_mgmt_datalake_analytics_2016_11_01": {
       "markdown": "specification/datalake-analytics/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::DataLakeAnalytics",
+        "namespace": "Azure::ARM::DataLakeAnalytics::Api_2016_11_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_datalake_analytics",
-        "package-version": "0.11.0"
+        "tag": "package-2016-11"
       },
-      "output_dir": "management/azure_mgmt_datalake_analytics/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_datalake_analytics.rb"
-      ]
+      "output_dir": "management/azure_mgmt_datalake_analytics/lib/2017-04-26",
+      "generated_relative_base_directory": "2017-04-26",
+      "build_dir": "management/azure_mgmt_datalake_analytics/lib/2017-04-26"
     },
-    "azure_mgmt_datalake_store": {
+    "azure_mgmt_datalake_analytics_2015_10_01_preview": {
+      "markdown": "specification/datalake-analytics/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::DataLakeAnalytics::Api_2015_10_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_datalake_analytics",
+        "tag": "package-2015-10-preview"
+      },
+      "output_dir": "management/azure_mgmt_datalake_analytics/lib/2015-10-01-preview",
+      "generated_relative_base_directory": "2015-10-01-preview",
+      "build_dir": "management/azure_mgmt_datalake_analytics/lib/2015-10-01-preview"
+    },
+    "azure_mgmt_datalake_store_2016_11_01": {
       "markdown": "specification/datalake-store/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::DataLakeStore",
+        "namespace": "Azure::ARM::DataLakeStore::Api_2016_11_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_datalake_store",
-        "package-version": "0.11.0"
+        "tag": "package-2016-11"
       },
-      "output_dir": "management/azure_mgmt_datalake_store/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_datalake_store.rb"
-      ]
+      "output_dir": "management/azure_mgmt_datalake_store/lib/2016-11-01",
+      "generated_relative_base_directory": "2016-11-01",
+      "build_dir": "management/azure_mgmt_datalake_store/lib/2016-11-01"
     },
-    "azure_mgmt_devtestlabs": {
-      "markdown": "specification/devtestlabs/resource-manager/readme.md",
+    "azure_mgmt_datalake_store_2015_10_01_preview": {
+      "markdown": "specification/datalake-store/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::DevTestLabs",
-        "package-name": "azure_mgmt_devtestlabs",
-        "package-version": "0.11.0"
+        "namespace": "Azure::ARM::DataLakeStore::Api_2015_10_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_datalake_store",
+        "tag": "package-2015-10-preview"
       },
-      "output_dir": "management/azure_mgmt_devtestlabs/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_devtestlabs.rb"
-      ]
+      "output_dir": "management/azure_mgmt_datalake_store/lib/2015-10-01-preview",
+      "generated_relative_base_directory": "2015-10-01-preview",
+      "build_dir": "management/azure_mgmt_datalake_store/lib/2015-10-01-preview"
     },
-    "azure_mgmt_dns": {
+    "azure_mgmt_dns_2016_04_01": {
       "markdown": "specification/dns/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Dns",
+        "namespace": "Azure::ARM::Dns::Api_2016_04_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_dns",
-        "package-version": "0.11.0"
+        "tag": "package-2016-04"
       },
-      "output_dir": "management/azure_mgmt_dns/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_dns.rb"
-      ]
+      "output_dir": "management/azure_mgmt_dns/lib/2016-04-01",
+      "generated_relative_base_directory": "2016-04-01",
+      "build_dir": "management/azure_mgmt_dns/lib/2016-04-01"
     },
-    "azure_mgmt_event_hub": {
+    "azure_mgmt_event_grid_2017_09_15_preview": {
+      "markdown": "specification/eventgrid/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::EventGrid::Api_2017_09_15_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_event_grid",
+        "tag": "package-2017-09-preview"
+      },
+      "output_dir": "management/azure_mgmt_event_grid/lib/2017-09-15-preview",
+      "generated_relative_base_directory": "2017-09-15-preview",
+      "build_dir": "management/azure_mgmt_event_grid/lib/2017-09-15-preview"
+    },
+    "azure_mgmt_event_grid_2017_06_15_preview": {
+      "markdown": "specification/eventgrid/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::EventGrid::Api_2017_06_15_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_event_grid",
+        "tag": "package-2017-06-preview"
+      },
+      "output_dir": "management/azure_mgmt_event_grid/lib/2017-06-15-preview",
+      "generated_relative_base_directory": "2017-06-15-preview",
+      "build_dir": "management/azure_mgmt_event_grid/lib/2017-06-15-preview"
+    },
+    "azure_mgmt_event_hub_2017_04_01": {
       "markdown": "specification/eventhub/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::EventHub",
+        "namespace": "Azure::ARM::EventHub::Api_2017_04_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_event_hub",
-        "package-version": "0.11.0"
+        "tag": "package-2017-04"
       },
-      "output_dir": "management/azure_mgmt_event_hub/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_event_hub.rb"
-      ]
+      "output_dir": "management/azure_mgmt_event_hub/lib/2017-04-01",
+      "generated_relative_base_directory": "2017-04-01",
+      "build_dir": "management/azure_mgmt_event_hub/lib/2017-04-01"
     },
-    "azure_mgmt_features": {
+    "azure_mgmt_event_hub_2015_08_01": {
+      "markdown": "specification/eventhub/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::EventHub::Api_2015_08_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_event_hub",
+        "tag": "package-2015-08"
+      },
+      "output_dir": "management/azure_mgmt_event_hub/lib/2015-08-01",
+      "generated_relative_base_directory": "2015-08-01",
+      "build_dir": "management/azure_mgmt_event_hub/lib/2015-08-01"
+    },
+    "azure_mgmt_features_2015_12_01": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Features",
-        "package-name": "azure_mgmt_features",
+        "namespace": "Azure::ARM::Features::Api_2015_12_01",
         "package-version": "0.11.0",
+        "package-name": "azure_mgmt_features",
         "tag": "package-features-2015-12"
       },
-      "output_dir": "management/azure_mgmt_features/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_features.rb"
-      ]
+      "output_dir": "management/azure_mgmt_features/lib/2015-12-01",
+      "generated_relative_base_directory": "2015-12-01",
+      "build_dir": "management/azure_mgmt_features/lib/2015-12-01"
     },
-    "azure_mgmt_graph": {
-      "markdown": "specification/graphrbac/data-plane/readme.md",
+    "azure_mgmt_graph_1.6": {
       "autorest_options": {
-        "namespace": "Azure::ARM::Graph",
+        "namespace": "Azure::ARM::Graph::Api_1_6",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_graph",
-        "package-version": "0.11.0"
+        "input-file": [
+          "specification/graphrbac/data-plane/1.6/graphrbac.json"
+        ]
       },
-      "output_dir": "management/azure_mgmt_graph/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_graph.rb"
-      ]
+      "output_dir": "management/azure_mgmt_graph/lib/1.6",
+      "generated_relative_base_directory": "1.6",
+      "build_dir": "management/azure_mgmt_graph/lib/1.6"
     },
-    "azure_mgmt_iot_hub": {
+    "azure_mgmt_iot_hub_2017_07_01": {
       "markdown": "specification/iothub/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::IotHub",
+        "namespace": "Azure::ARM::IotHub::Api_2017_07_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_iot_hub",
-        "package-version": "0.11.0"
+        "tag": "package-2017-07"
       },
-      "output_dir": "management/azure_mgmt_iot_hub/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_iot_hub.rb"
-      ]
+      "output_dir": "management/azure_mgmt_iot_hub/lib/2017-07-01",
+      "generated_relative_base_directory": "2017-07-01",
+      "build_dir": "management/azure_mgmt_iot_hub/lib/2017-07-01"
     },
-    "azure_mgmt_key_vault": {
-      "markdown": "specification/keyvault/resource-manager/readme.md",
+    "azure_mgmt_iot_hub_2017_01_19": {
+      "markdown": "specification/iothub/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::KeyVault",
-        "package-name": "azure_mgmt_key_vault",
-        "package-version": "0.11.0"
+        "namespace": "Azure::ARM::IotHub::Api_2017_01_19",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_iot_hub",
+        "tag": "package-2017-01"
       },
-      "output_dir": "management/azure_mgmt_key_vault/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_key_vault.rb"
-      ]
+      "output_dir": "management/azure_mgmt_iot_hub/lib/2017-01-19",
+      "generated_relative_base_directory": "2017-01-19",
+      "build_dir": "management/azure_mgmt_iot_hub/lib/2017-01-19"
     },
-    "azure_mgmt_locks": {
+    "azure_mgmt_iot_hub_2016_02_03": {
+      "markdown": "specification/iothub/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::IotHub::Api_2016_02_03",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_iot_hub",
+        "tag": "package-2016-02"
+      },
+      "output_dir": "management/azure_mgmt_iot_hub/lib/2016-02-03",
+      "generated_relative_base_directory": "2016-02-03",
+      "build_dir": "management/azure_mgmt_iot_hub/lib/2016-02-03"
+    },
+    "azure_mgmt_key_vault_2016_10_01": {
+      "markdown": "specification/iothub/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::KeyVault::Api_2016_10_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_key_vault",
+        "tag": "package-2016-10"
+      },
+      "output_dir": "management/azure_mgmt_key_vault/lib/2016-10-01",
+      "generated_relative_base_directory": "2016-10-01",
+      "build_dir": "management/azure_mgmt_key_vault/lib/2016-10-01"
+    },
+    "azure_mgmt_key_vault_2015_06_01": {
+      "markdown": "specification/iothub/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::KeyVault::Api_2015_06_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_key_vault",
+        "tag": "package-2015-06"
+      },
+      "output_dir": "management/azure_mgmt_key_vault/lib/2015-06-01",
+      "generated_relative_base_directory": "2015-06-01",
+      "build_dir": "management/azure_mgmt_key_vault/lib/2015-06-01"
+    },
+    "azure_mgmt_links_2016_09_01": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Locks",
-        "package-name": "azure_mgmt_locks",
+        "namespace": "Azure::ARM::Links::Api_2016_09_01",
         "package-version": "0.11.0",
+        "package-name": "azure_mgmt_links",
+        "tag": "package-links-2016-09",
+        "title": "LinksManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_links/lib/2015-06-01",
+      "generated_relative_base_directory": "2015-06-01",
+      "build_dir": "management/azure_mgmt_links/lib/2015-06-01"
+    },
+    "azure_mgmt_locks_2016_09_01": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Locks::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_locks",
         "tag": "package-locks-2016-09"
       },
-      "output_dir": "management/azure_mgmt_locks/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_locks.rb"
-      ]
+      "output_dir": "management/azure_mgmt_locks/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_locks/lib/2016-09-01"
     },
-    "azure_mgmt_logic": {
+    "azure_mgmt_locks_2015_01_01": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Locks::Api_2015_01_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_locks",
+        "tag": "package-locks-2015-01"
+      },
+      "output_dir": "management/azure_mgmt_locks/lib/2015-01-01",
+      "generated_relative_base_directory": "2015-01-01",
+      "build_dir": "management/azure_mgmt_locks/lib/2015-01-01"
+    },
+    "azure_mgmt_logic_2016_06_01": {
       "markdown": "specification/logic/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Logic",
+        "namespace": "Azure::ARM::Logic::Api_2016_06_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_logic",
-        "package-version": "0.11.0"
+        "tag": "package-2016-06"
       },
-      "output_dir": "management/azure_mgmt_logic/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_logic.rb"
-      ]
+      "output_dir": "management/azure_mgmt_logic/lib/2016-06-01",
+      "generated_relative_base_directory": "2016-06-01",
+      "build_dir": "management/azure_mgmt_logic/lib/2016-06-01"
     },
-    "azure_mgmt_machine_learning": {
+    "azure_mgmt_logic_2015_02_01_preview": {
+      "markdown": "specification/logic/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Logic::Api_2015_02_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_logic",
+        "tag": "package-2015-02-preview"
+      },
+      "output_dir": "management/azure_mgmt_logic/lib/2015-02-01-preview",
+      "generated_relative_base_directory": "2015-02-01-preview",
+      "build_dir": "management/azure_mgmt_logic/lib/2015-02-01-preview"
+    },
+    "azure_mgmt_web_services_2017_01_01": {
       "markdown": "specification/machinelearning/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::MachineLearning",
+        "namespace": "Azure::ARM::MachineLearning::Api_2017_01_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_machine_learning",
-        "package-version": "0.11.0"
+        "tag": "package-webservices-2017-01"
       },
-      "output_dir": "management/azure_mgmt_machine_learning/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_machine_learning.rb"
-      ]
+      "output_dir": "management/azure_mgmt_machine_learning/lib/2017-01-01",
+      "generated_relative_base_directory": "2017-01-01",
+      "build_dir": "management/azure_mgmt_machine_learning/lib/2017-01-01"
     },
-    "azure_mgmt_media_services": {
+    "azure_mgmt_managed_applications_2016_09_01_preview": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ManagedApplications::Api_2016_09_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_managed_applications",
+        "tag": "package-managedapplications-2016-09"
+      },
+      "output_dir": "management/azure_mgmt_managed_applications/lib/2016-09-01-preview",
+      "generated_relative_base_directory": "2016-09-01-preview",
+      "build_dir": "management/azure_mgmt_managed_applications/lib/2016-09-01-preview"
+    },
+    "azure_mgmt_marketplace_ordering_2015_06_01": {
+      "markdown": "specification/marketplaceordering/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::MarketplaceOrdering::Api_2015_06_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_marketplace_ordering",
+        "tag": "package-2015-06-01"
+      },
+      "output_dir": "management/azure_mgmt_marketplace_ordering/lib/2015-06-01",
+      "generated_relative_base_directory": "2015-06-01",
+      "build_dir": "management/azure_mgmt_marketplace_ordering/lib/2015-06-01"
+    },
+    "azure_mgmt_media_services_2015_10_01": {
       "markdown": "specification/mediaservices/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::MediaServices",
+        "namespace": "Azure::ARM::MediaServices::Api_2015_10_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_media_services",
-        "package-version": "0.11.0"
+        "tag": "package-2015-10"
       },
-      "output_dir": "management/azure_mgmt_media_services/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_media_services.rb"
-      ]
+      "output_dir": "management/azure_mgmt_media_services/lib/2015-10-01",
+      "generated_relative_base_directory": "2015-10-01",
+      "build_dir": "management/azure_mgmt_media_services/lib/2015-10-01"
     },
-    "azure_mgmt_mobile_engagement": {
+    "azure_mgmt_mobile_engagement_2014_12_01": {
       "markdown": "specification/mobileengagement/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::MobileEngagement",
+        "namespace": "Azure::ARM::MobileEngagement::Api_2014_12_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_mobile_engagement",
-        "package-version": "0.11.0"
+        "tag": "package-2014-12"
       },
-      "output_dir": "management/azure_mgmt_mobile_engagement/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_mobile_engagement.rb"
-      ]
+      "output_dir": "management/azure_mgmt_mobile_engagement/lib/2014-12-01",
+      "generated_relative_base_directory": "2014-12-01",
+      "build_dir": "management/azure_mgmt_mobile_engagement/lib/2014-12-01"
     },
-    "azure_mgmt_monitor": {
-      "markdown": "specification/monitor/resource-manager/readme.md",
+    "azure_mgmt_monitor_2017_05_01_preview": {
       "autorest_options": {
-        "namespace": "Azure::ARM::Monitor",
+        "namespace": "Azure::ARM::MobileEngagement::Api_2014_12_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_monitor",
-        "package-version": "0.11.0"
+        "input-file": [
+          "specification/monitor/resource-manager/microsoft.insights/2017-05-01-preview/diagnosticsSettingsCategories_API.json",
+          "specification/monitor/resource-manager/microsoft.insights/2017-05-01-preview/diagnosticsSettings_API.json"
+        ],
+        "title": "MonitorClient"
       },
-      "output_dir": "management/azure_mgmt_monitor/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_monitor.rb"
-      ]
+      "output_dir": "management/azure_mgmt_monitor/lib/2017-05-01-preview",
+      "generated_relative_base_directory": "2017-05-01-preview",
+      "build_dir": "management/azure_mgmt_monitor/lib/2017-05-01-preview"
     },
-    "azure_mgmt_network": {
+    "azure_mgmt_monitor_2017_04_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Monitor::Api_2017_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_monitor",
+        "input-file": [
+          "specification/monitor/resource-manager/microsoft.insights/2017-04-01/actionGroups_API.json",
+          "specification/monitor/resource-manager/microsoft.insights/2017-04-01/activityLogAlerts_API.json"
+        ],
+        "title": "MonitorClient"
+      },
+      "output_dir": "management/azure_mgmt_monitor/lib/2017-04-01",
+      "generated_relative_base_directory": "2017-04-01",
+      "build_dir": "management/azure_mgmt_monitor/lib/2017-04-01"
+    },
+    "azure_mgmt_monitor_2016_09_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Monitor::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_monitor",
+        "input-file": [
+          "specification/monitor/resource-manager/microsoft.insights/2016-09-01/serviceDiagnosticsSettings_API.json"
+        ],
+        "title": "MonitorClient"
+      },
+      "output_dir": "management/azure_mgmt_monitor/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_monitor/lib/2016-09-01"
+    },
+    "azure_mgmt_monitor_2016_03_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Monitor::Api_2016_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_monitor",
+        "input-file": [
+          "specification/monitor/resource-manager/microsoft.insights/2016-03-01/alertRulesIncidents_API.json",
+          "specification/monitor/resource-manager/microsoft.insights/2016-03-01/alertRules_API.json",
+          "specification/monitor/resource-manager/microsoft.insights/2016-03-01/logProfiles_API.json"
+        ],
+        "title": "MonitorClient"
+      },
+      "output_dir": "management/azure_mgmt_monitor/lib/2016-03-01",
+      "generated_relative_base_directory": "2016-03-01",
+      "build_dir": "management/azure_mgmt_monitor/lib/2016-03-01"
+    },
+    "azure_mgmt_monitor_2015_04_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Monitor::Api_2015_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_monitor",
+        "input-file": [
+          "specification/monitor/resource-manager/microsoft.insights/2015-04-01/autoscale_API.json",
+          "specification/monitor/resource-manager/microsoft.insights/2015-04-01/operations_API.json"
+        ],
+        "title": "MonitorClient"
+      },
+      "output_dir": "management/azure_mgmt_monitor/lib/2015-04-01",
+      "generated_relative_base_directory": "2015-04-01",
+      "build_dir": "management/azure_mgmt_monitor/lib/2015-04-01"
+    },
+    "azure_mgmt_network_2017_09_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2017_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "input-file": [
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/applicationGateway.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/applicationSecurityGroup.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/checkDnsAvailability.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/endpointService.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/expressRouteCircuit.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/loadBalancer.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/network.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/networkInterface.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/networkSecurityGroup.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/networkWatcher.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/publicIpAddress.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/routeFilter.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/serviceCommunity.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/routeTable.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/usage.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/virtualNetwork.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/virtualNetworkGateway.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2017-09-01",
+      "generated_relative_base_directory": "2017-09-01",
+      "build_dir": "management/azure_mgmt_network/lib/2017-09-01"
+    },
+    "azure_mgmt_network_2017_03_30": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2017_03_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "input-file": [
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/vmssNetworkInterface.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-09-01/vmssPublicIpAddress.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2017-03-30",
+      "generated_relative_base_directory": "2017-03-30",
+      "build_dir": "management/azure_mgmt_network/lib/2017-03-30"
+    },
+    "azure_mgmt_network_2017_03_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2017_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "input-file": [
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/applicationGateway.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/checkDnsAvailability.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/expressRouteCircuit.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/loadBalancer.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/network.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/networkInterface.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/networkSecurityGroup.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/networkWatcher.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/publicIpAddress.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/routeFilter.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/routeTable.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/serviceCommunity.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/usage.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/virtualNetwork.json",
+          "specification/network/resource-manager/Microsoft.Network/2017-03-01/virtualNetworkGateway.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2017-03-01",
+      "generated_relative_base_directory": "2017-03-01",
+      "build_dir": "management/azure_mgmt_network/lib/2017-03-01"
+    },
+    "azure_mgmt_network_2016_12_01": {
       "markdown": "specification/network/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Network",
+        "namespace": "Azure::ARM::Network::Api_2016_12_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_network",
-        "package-version": "0.11.0"
+        "tag": "package-2016-12"
       },
-      "output_dir": "management/azure_mgmt_network/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_network.rb"
-      ]
+      "output_dir": "management/azure_mgmt_network/lib/2016-12-01",
+      "generated_relative_base_directory": "2016-12-01",
+      "build_dir": "management/azure_mgmt_network/lib/2016-12-01"
     },
-    "azure_mgmt_notification_hubs": {
+    "azure_mgmt_network_2016_09_01": {
+      "markdown": "specification/network/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "tag": "package-2016-09"
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_network/lib/2016-09-01"
+    },
+    "azure_mgmt_network_2016_06_01": {
+      "markdown": "specification/network/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2016_06_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "tag": "package-2016-06"
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2016-06-01",
+      "generated_relative_base_directory": "2016-06-01",
+      "build_dir": "management/azure_mgmt_network/lib/2016-06-01"
+    },
+    "azure_mgmt_network_2016_03_30": {
+      "markdown": "specification/network/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2016_03_30",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "tag": "package-2016-03"
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2016-03-30",
+      "generated_relative_base_directory": "2016-03-30",
+      "build_dir": "management/azure_mgmt_network/lib/2016-03-30"
+    },
+    "azure_mgmt_network_2015_06_15": {
+      "markdown": "specification/network/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2015_06_15",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "tag": "package-2015-06split"
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2015-06-15",
+      "generated_relative_base_directory": "2015-06-15",
+      "build_dir": "management/azure_mgmt_network/lib/2015-06-15"
+    },
+    "azure_mgmt_network_2015_05_01_preview": {
+      "markdown": "specification/network/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Network::Api_2015_05_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_network",
+        "tag": "package-2015-05-preview"
+      },
+      "output_dir": "management/azure_mgmt_network/lib/2015-05-01-preview",
+      "generated_relative_base_directory": "2015-05-01-preview",
+      "build_dir": "management/azure_mgmt_network/lib/2015-05-01-preview"
+    },
+    "azure_mgmt_notification_hubs_2017_04_01": {
       "markdown": "specification/notificationhubs/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::NotificationHubs",
+        "namespace": "Azure::ARM::NotificationHubs::Api_2017_04_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_notification_hubs",
-        "package-version": "0.11.0"
+        "tag": "package-2017-04"
       },
-      "output_dir": "management/azure_mgmt_notification_hubs/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_notification_hubs.rb"
-      ]
+      "output_dir": "management/azure_mgmt_notification_hubs/lib/2017-04-01",
+      "generated_relative_base_directory": "2017-04-01",
+      "build_dir": "management/azure_mgmt_notification_hubs/lib/2017-04-01"
     },
-    "azure_mgmt_policy": {
+    "azure_mgmt_operational_insights_2015_11_01_preview": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::OperationalInsights::Api_2015_11_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_operational_insights",
+        "input-file": [
+          "specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/2015-11-01-preview/OperationalInsights.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_operational_insights/lib/2015-11-01-preview",
+      "generated_relative_base_directory": "2015-11-01-preview",
+      "build_dir": "management/azure_mgmt_operational_insights/lib/2015-11-01-preview"
+    },
+    "azure_mgmt_operational_insights_2015_03_20": {
+      "markdown": "specification/operationalinsights/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::OperationalInsights::Api_2015_03_20",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_operational_insights",
+        "tag": "package-2015-03"
+      },
+      "output_dir": "management/azure_mgmt_operational_insights/lib/2015-03-20",
+      "generated_relative_base_directory": "2015-03-20",
+      "build_dir": "management/azure_mgmt_operational_insights/lib/2015-03-20"
+    },
+    "azure_mgmt_policy_2017_06_01_preview": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Policy::Api_2017_06_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_policy",
+        "input-file": [
+          "specification/resources/resource-manager/Microsoft.Authorization/2017-06-01-preview/policyAssignments.json",
+          "specification/resources/resource-manager/Microsoft.Authorization/2017-06-01-preview/policySetDefinitions.json"
+        ],
+        "title": "PolicyClient"
+      },
+      "output_dir": "management/azure_mgmt_policy/lib/2017-06-01-preview",
+      "generated_relative_base_directory": "2017-06-01-preview",
+      "build_dir": "management/azure_mgmt_policy/lib/2017-06-01-preview"
+    },
+    "azure_mgmt_policy_2016_12_01": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Policy",
-        "package-name": "azure_mgmt_policy",
+        "namespace": "Azure::ARM::Policy::Api_2016_12_01",
         "package-version": "0.11.0",
+        "package-name": "azure_mgmt_policy",
         "tag": "package-policy-2016-12"
       },
-      "output_dir": "management/azure_mgmt_policy/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_policy.rb"
-      ]
+      "output_dir": "management/azure_mgmt_policy/lib/2016-12-01",
+      "generated_relative_base_directory": "2016-12-01",
+      "build_dir": "management/azure_mgmt_policy/lib/2016-12-01"
     },
-    "azure_mgmt_powerbi_embedded": {
+    "azure_mgmt_policy_2016_04_01": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Policy::Api_2016_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_policy",
+        "tag": "package-policy-2016-04"
+      },
+      "output_dir": "management/azure_mgmt_policy/lib/2016-04-01",
+      "generated_relative_base_directory": "2016-04-01",
+      "build_dir": "management/azure_mgmt_policy/lib/2016-04-01"
+    },
+    "azure_mgmt_policy_2015_10_01_preview": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Policy::Api_2015_10_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_policy",
+        "tag": "package-policy-2015-10"
+      },
+      "output_dir": "management/azure_mgmt_policy/lib/2015-10-01-preview",
+      "generated_relative_base_directory": "2015-10-01-preview",
+      "build_dir": "management/azure_mgmt_policy/lib/2015-10-01-preview"
+    },
+    "azure_mgmt_powerbi_embedded_2016_01_29": {
       "markdown": "specification/powerbiembedded/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::PowerBiEmbedded",
+        "namespace": "Azure::ARM::PowerBiEmbedded::Api_2016_01_29",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_powerbi_embedded",
-        "package-version": "0.11.0"
+        "tag": "package-2016-01"
       },
-      "output_dir": "management/azure_mgmt_powerbi_embedded/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_powerbi_embedded.rb"
-      ]
+      "output_dir": "management/azure_mgmt_powerbi_embedded/lib/2016-01-29",
+      "generated_relative_base_directory": "2016-01-29",
+      "build_dir": "management/azure_mgmt_powerbi_embedded/lib/2016-01-29"
     },
-    "azure_mgmt_recovery_services": {
+    "azure_mgmt_recovery_services_2016_12_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::RecoveryServices::Api_2016_12_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_recovery_services",
+        "input-file": [
+          "specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/2016-12-01/backup.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_recovery_services/lib/2016-12-01",
+      "generated_relative_base_directory": "2016-12-01",
+      "build_dir": "management/azure_mgmt_recovery_services/lib/2016-12-01"
+    },
+    "azure_mgmt_recovery_services_2016_06_01": {
       "markdown": "specification/recoveryservices/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::RecoveryServices",
+        "namespace": "Azure::ARM::RecoveryServices::Api_2016_06_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_recovery_services",
-        "package-version": "0.11.0"
+        "tag": "package-2016-06"
       },
-      "output_dir": "management/azure_mgmt_recovery_services/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_recovery_services.rb"
-      ]
+      "output_dir": "management/azure_mgmt_recovery_services/lib/2016-06-01",
+      "generated_relative_base_directory": "2016-06-01",
+      "build_dir": "management/azure_mgmt_recovery_services/lib/2016-06-01"
     },
-    "azure_mgmt_recovery_services_backup": {
+    "azure_mgmt_recovery_services_backup_2017_07_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2017_07_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_recovery_services_backup",
+        "input-file": [
+          "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2017-07-01/jobs.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_recovery_services_backup/lib/2017-07-01",
+      "generated_relative_base_directory": "2017-07-01",
+      "build_dir": "management/azure_mgmt_recovery_services_backup/lib/2017-07-01"
+    },
+    "azure_mgmt_recovery_services_backup_2016_12_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_12_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_recovery_services_backup",
+        "input-file": [
+          "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2016-12-01/backupManagement.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-12-01",
+      "generated_relative_base_directory": "2016-12-01",
+      "build_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-12-01"
+    },
+    "azure_mgmt_recovery_services_backup_2016_08_10": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_08_10",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_recovery_services_backup",
+        "input-file": [
+          "specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/2016-08-10/operations.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-08-10",
+      "generated_relative_base_directory": "2016-08-10",
+      "build_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-08-10"
+    },
+    "azure_mgmt_recovery_services_backup_2016_06_01": {
       "markdown": "specification/recoveryservicesbackup/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::RecoveryServicesBackup",
+        "namespace": "Azure::ARM::RecoveryServicesBackup::Api_2016_06_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_recovery_services_backup",
-        "package-version": "0.11.0"
+        "tag": "package-2016-06"
       },
-      "output_dir": "management/azure_mgmt_recovery_services_backup/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_recovery_services_backup.rb"
-      ]
+      "output_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-06-01",
+      "generated_relative_base_directory": "2016-06-01",
+      "build_dir": "management/azure_mgmt_recovery_services_backup/lib/2016-06-01"
     },
-    "azure_mgmt_redis": {
+    "azure_mgmt_recovery_services_2016_08_10": {
+      "markdown": "specification/recoveryservicessiterecovery/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::RecoveryServicesSiteRecovery::Api_2016_08_10",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_recovery_services_site_recovery",
+        "tag": "package-2016-08"
+      },
+      "output_dir": "management/azure_mgmt_recovery_services_site_recovery/lib/2016-08-10",
+      "generated_relative_base_directory": "2016-08-10",
+      "build_dir": "management/azure_mgmt_recovery_services_site_recovery/lib/2016-08-10"
+    },
+    "azure_mgmt_redis_2017_02_01": {
       "markdown": "specification/redis/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Redis",
+        "namespace": "Azure::ARM::Redis::Api_2017_02_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_redis",
-        "package-version": "0.11.0"
+        "tag": "package-2017-02"
       },
-      "output_dir": "management/azure_mgmt_redis/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_redis.rb"
-      ]
+      "output_dir": "management/azure_mgmt_redis/lib/2017-02-01",
+      "generated_relative_base_directory": "2017-02-01",
+      "build_dir": "management/azure_mgmt_redis/lib/2017-02-01"
     },
-    "azure_mgmt_resources": {
+    "azure_mgmt_redis_2016_04_01": {
+      "markdown": "specification/redis/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Redis::Api_2016_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_redis",
+        "tag": "package-2016-04"
+      },
+      "output_dir": "management/azure_mgmt_redis/lib/2016-04-01",
+      "generated_relative_base_directory": "2016-04-01",
+      "build_dir": "management/azure_mgmt_redis/lib/2016-04-01"
+    },
+    "azure_mgmt_redis_2015_08_01": {
+      "markdown": "specification/redis/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Redis::Api_2015_08_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_redis",
+        "tag": "package-2015-08"
+      },
+      "output_dir": "management/azure_mgmt_redis/lib/2015-08-01",
+      "generated_relative_base_directory": "2015-08-01",
+      "build_dir": "management/azure_mgmt_redis/lib/2015-08-01"
+    },
+    "azure_mgmt_relay_2017_04_01": {
+      "markdown": "specification/relay/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Relay::Api_2017_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_relay",
+        "tag": "package-2017-04"
+      },
+      "output_dir": "management/azure_mgmt_relay/lib/2017-04-01",
+      "generated_relative_base_directory": "2017-04-01",
+      "build_dir": "management/azure_mgmt_relay/lib/2017-04-01"
+    },
+    "azure_mgmt_relay_2016_07_01": {
+      "markdown": "specification/relay/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Relay::Api_2016_07_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_relay",
+        "tag": "package-2016-07"
+      },
+      "output_dir": "management/azure_mgmt_relay/lib/2016-07-01",
+      "generated_relative_base_directory": "2016-07-01",
+      "build_dir": "management/azure_mgmt_relay/lib/2016-07-01"
+    },
+    "azure_mgmt_resources_2017_05_10": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Resources::Api_2017_05_10",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_resources",
+        "input-file": [
+          "specification/resources/resource-manager/Microsoft.Resources/2017-05-10/resources.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_resources/lib/2017-05-10",
+      "generated_relative_base_directory": "2017-05-10",
+      "build_dir": "management/azure_mgmt_resources/lib/2017-05-10"
+    },
+    "azure_mgmt_resources_2016_09_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Resources::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_resources",
+        "input-file": [
+          "specification/resources/resource-manager/Microsoft.Resources/2016-09-01/resources.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_resources/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_resources/lib/2016-09-01"
+    },
+    "azure_mgmt_resources_2016_07_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Resources::Api_2016_07_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_resources",
+        "input-file": [
+          "specification/resources/resource-manager/Microsoft.Resources/2016-07-01/resources.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_resources/lib/2016-07-01",
+      "generated_relative_base_directory": "2016-07-01",
+      "build_dir": "management/azure_mgmt_resources/lib/2016-07-01"
+    },
+    "azure_mgmt_resources_management_2017_08_31_preview": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Resources",
-        "package-name": "azure_mgmt_resources",
+        "namespace": "Azure::ARM::ResourcesManagement::Api_2017_08_31_preview",
         "package-version": "0.11.0",
-        "tag": "package-resources-2017-05"
+        "package-name": "azure_mgmt_resources_management",
+        "tag": "package-management-2017-08"
       },
-      "output_dir": "management/azure_mgmt_resources/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_resources.rb"
-      ]
+      "output_dir": "management/azure_mgmt_resources_management/lib/2017-08-31-preview",
+      "generated_relative_base_directory": "2017-08-31-preview",
+      "build_dir": "management/azure_mgmt_resources_management/lib/2017-08-31-preview"
     },
-    "azure_mgmt_scheduler": {
+    "azure_mgmt_scheduler_2016_03_01": {
       "markdown": "specification/scheduler/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Scheduler",
+        "namespace": "Azure::ARM::Scheduler::Api_2016_03_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_scheduler",
-        "package-version": "0.11.0"
+        "tag": "package-2016-03"
       },
-      "output_dir": "management/azure_mgmt_scheduler/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_scheduler.rb"
-      ]
+      "output_dir": "management/azure_mgmt_scheduler/lib/2017-08-31-preview",
+      "generated_relative_base_directory": "2017-08-31-preview",
+      "build_dir": "management/azure_mgmt_scheduler/lib/2017-08-31-preview"
     },
-    "azure_mgmt_search": {
+    "azure_mgmt_search_2015_08_19": {
       "markdown": "specification/search/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Search",
+        "namespace": "Azure::ARM::Search::Api_2015_08_19",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_search",
-        "package-version": "0.11.0"
+        "tag": "package-2015-08"
       },
-      "output_dir": "management/azure_mgmt_search/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_search.rb"
-      ]
+      "output_dir": "management/azure_mgmt_search/lib/2015-08-19",
+      "generated_relative_base_directory": "2015-08-19",
+      "build_dir": "management/azure_mgmt_search/lib/2015-08-19"
     },
-    "azure_mgmt_server_management": {
+    "azure_mgmt_server_management_2016_07_01_preview": {
       "markdown": "specification/servermanagement/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::ServerManagement",
+        "namespace": "Azure::ARM::ServerManagement::Api_2016_07_01_preview",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_server_management",
-        "package-version": "0.11.0"
+        "tag": "package-2016-07-preview"
       },
-      "output_dir": "management/azure_mgmt_server_management/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_server_management.rb"
-      ]
+      "output_dir": "management/azure_mgmt_server_management/lib/2016-07-01-preview",
+      "generated_relative_base_directory": "2016-07-01-preview",
+      "build_dir": "management/azure_mgmt_server_management/lib/2016-07-01-preview"
     },
-    "azure_mgmt_service_bus": {
+    "azure_mgmt_service_bus_2017_04_01": {
       "markdown": "specification/servicebus/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::ServiceBus",
+        "namespace": "Azure::ARM::ServiceBus::Api_2017_04_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_service_bus",
-        "package-version": "0.11.0"
+        "tag": "package-2017-04"
       },
-      "output_dir": "management/azure_mgmt_service_bus/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_service_bus.rb"
-      ]
+      "output_dir": "management/azure_mgmt_service_bus/lib/2017-04-01",
+      "generated_relative_base_directory": "2017-04-01",
+      "build_dir": "management/azure_mgmt_service_bus/lib/2017-04-01"
     },
-    "azure_mgmt_sql": {
+    "azure_mgmt_service_bus_2015_08_01": {
+      "markdown": "specification/servicebus/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ServiceBus::Api_2015_08_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_service_bus",
+        "tag": "package-2015-08"
+      },
+      "output_dir": "management/azure_mgmt_service_bus/lib/2015-08-01",
+      "generated_relative_base_directory": "2015-08-01",
+      "build_dir": "management/azure_mgmt_service_bus/lib/2015-08-01"
+    },
+    "azure_mgmt_service_fabric_2016_09_01": {
+      "markdown": "specification/servicefabric/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::ServiceFabric::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_service_fabric",
+        "tag": "package-2016-09"
+      },
+      "output_dir": "management/azure_mgmt_service_fabric/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_service_fabric/lib/2016-09-01"
+    },
+    "azure_mgmt_sql_2014_04_01": {
       "markdown": "specification/sql/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::SQL",
+        "namespace": "Azure::ARM::SQL::Api_2014_04_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_sql",
-        "package-version": "0.11.0"
+        "tag": "schema-2014-04"
       },
-      "output_dir": "management/azure_mgmt_sql/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_sql.rb"
-      ]
+      "output_dir": "management/azure_mgmt_sql/lib/2014-04-01",
+      "generated_relative_base_directory": "2014-04-01",
+      "build_dir": "management/azure_mgmt_sql/lib/2014-04-01"
     },
-    "azure_mgmt_storage": {
+    "azure_mgmt_sql_2015_05_01_preview": {
+      "markdown": "specification/sql/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::SQL::Api_2015_05_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_sql",
+        "tag": "schema-2015-05-preview"
+      },
+      "output_dir": "management/azure_mgmt_sql/lib/2015-05-01-preview",
+      "generated_relative_base_directory": "2015-05-01-preview",
+      "build_dir": "management/azure_mgmt_sql/lib/2015-05-01-preview"
+    },
+    "azure_mgmt_sql_2017_03_01_preview": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::SQL::Api_2017_03_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_sql",
+        "input-file": [
+          "specification/sql/resource-manager/Microsoft.Sql/2017-03-01-preview/cancelOperations.json"
+        ]
+      },
+      "output_dir": "management/azure_mgmt_sql/lib/2017-03-01-preview",
+      "generated_relative_base_directory": "2017-03-01-preview",
+      "build_dir": "management/azure_mgmt_sql/lib/2017-03-01-preview"
+    },
+    "azure_mgmt_stor_simple8000_series_2017_06_01": {
+      "markdown": "specification/storsimple8000series/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::StorSimple8000Series::Api_2017_06_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_stor_simple8000_series",
+        "tag": "package-2017-06"
+      },
+      "output_dir": "management/azure_mgmt_stor_simple8000_series/lib/2017-06-01",
+      "generated_relative_base_directory": "2017-06-01",
+      "build_dir": "management/azure_mgmt_stor_simple8000_series/lib/2017-06-01"
+    },
+    "azure_mgmt_storage_2017_06_01": {
       "markdown": "specification/storage/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Storage",
+        "namespace": "Azure::ARM::Storage::Api_2017_06_01",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_storage",
-        "package-version": "0.11.0"
+        "tag": "package-2017-06"
       },
-      "output_dir": "management/azure_mgmt_storage/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_storage.rb"
-      ]
+      "output_dir": "management/azure_mgmt_storage/lib/2017-06-01",
+      "generated_relative_base_directory": "2017-06-01",
+      "build_dir": "management/azure_mgmt_storage/lib/2017-06-01"
     },
-    "azure_mgmt_stream_analytics": {
-        "markdown": "specification/streamanalytics/resource-manager/readme.md",
-        "autorest_options": {
-          "Namespace": "Azure::ARM::StreamAnalytics",
-          "PackageName": "azure_mgmt_stream_analytics",
-          "PackageVersion": "0.10.0"
-        },
-        "output_dir": "management/azure_mgmt_stream_analytics/lib",
-        "wrapper_filesOrDirs": [
-          "azure_mgmt_stream_analytics.rb"
-        ]
+    "azure_mgmt_storage_2016_12_01": {
+      "markdown": "specification/storage/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Storage::Api_2016_12_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_storage",
+        "tag": "package-2016-12"
+      },
+      "output_dir": "management/azure_mgmt_storage/lib/2016-12-01",
+      "generated_relative_base_directory": "2016-12-01",
+      "build_dir": "management/azure_mgmt_storage/lib/2016-12-01"
     },
-    "azure_mgmt_subscriptions": {
+    "azure_mgmt_storage_2016_01_01": {
+      "markdown": "specification/storage/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Storage::Api_2016_01_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_storage",
+        "tag": "package-2016-01"
+      },
+      "output_dir": "management/azure_mgmt_storage/lib/2016-01-01",
+      "generated_relative_base_directory": "2016-01-01",
+      "build_dir": "management/azure_mgmt_storage/lib/2016-01-01"
+    },
+    "azure_mgmt_storage_2015_06_15": {
+      "markdown": "specification/storage/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Storage::Api_2015_06_15",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_storage",
+        "tag": "package-2015-06"
+      },
+      "output_dir": "management/azure_mgmt_storage/lib/2015-06-15",
+      "generated_relative_base_directory": "2015-06-15",
+      "build_dir": "management/azure_mgmt_storage/lib/2015-06-15"
+    },
+    "azure_mgmt_storage_2015_05_01_preview": {
+      "markdown": "specification/storage/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Storage::Api_2015_05_01_preview",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_storage",
+        "tag": "package-2015-05-preview"
+      },
+      "output_dir": "management/azure_mgmt_storage/lib/2015-05-01-preview",
+      "generated_relative_base_directory": "2015-05-01-preview",
+      "build_dir": "management/azure_mgmt_storage/lib/2015-05-01-preview"
+    },
+    "azure_mgmt_stream_analytics_2016_03_01": {
+      "markdown": "specification/streamanalytics/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::StreamAnalytics::Api_2016_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_stream_analytics",
+        "tag": "package-2016-03"
+      },
+      "output_dir": "management/azure_mgmt_stream_analytics/lib/2016-03-01",
+      "generated_relative_base_directory": "2016-03-01",
+      "build_dir": "management/azure_mgmt_stream_analytics/lib/2016-03-01"
+    },
+    "azure_mgmt_subscriptions_2016_06_01": {
       "markdown": "specification/resources/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Subscriptions",
-        "package-name": "azure_mgmt_subscriptions",
+        "namespace": "Azure::ARM::Subscriptions::Api_2016_06_01",
         "package-version": "0.11.0",
+        "package-name": "azure_mgmt_subscriptions",
         "tag": "package-subscriptions-2016-06"
       },
-      "output_dir": "management/azure_mgmt_subscriptions/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_subscriptions.rb"
-      ]
+      "output_dir": "management/azure_mgmt_subscriptions/lib/2016-06-01",
+      "generated_relative_base_directory": "2016-06-01",
+      "build_dir": "management/azure_mgmt_subscriptions/lib/2016-06-01"
     },
-    "azure_mgmt_traffic_manager": {
+    "azure_mgmt_subscriptions_2015_11_01": {
+      "markdown": "specification/resources/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::Subscriptions::Api_2015_11_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_subscriptions",
+        "tag": "package-subscriptions-2015-11"
+      },
+      "output_dir": "management/azure_mgmt_subscriptions/lib/2015-11-01",
+      "generated_relative_base_directory": "2015-11-01",
+      "build_dir": "management/azure_mgmt_subscriptions/lib/2015-11-01"
+    },
+    "azure_mgmt_traffic_manager_2017_09_01_preview": {
       "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::TrafficManager",
+        "namespace": "Azure::ARM::TrafficManager::Api_2017_09_01_preview",
+        "package-version": "0.11.0",
         "package-name": "azure_mgmt_traffic_manager",
-        "package-version": "0.11.0"
+        "tag": "package-2017-09-preview"
       },
-      "output_dir": "management/azure_mgmt_traffic_manager/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_traffic_manager.rb"
-      ]
+      "output_dir": "management/azure_mgmt_traffic_manager/lib/2017-09-01-preview",
+      "generated_relative_base_directory": "2017-09-01-preview",
+      "build_dir": "management/azure_mgmt_traffic_manager/lib/2017-09-01-preview"
     },
-    "azure_mgmt_web": {
-      "markdown": "specification/web/resource-manager/readme.md",
+    "azure_mgmt_traffic_manager_2017_05_01": {
+      "markdown": "specification/trafficmanager/resource-manager/readme.md",
       "autorest_options": {
-        "namespace": "Azure::ARM::Web",
-        "package-name": "azure_mgmt_web",
-        "package-version": "0.11.0"
+        "namespace": "Azure::ARM::TrafficManager::Api_2017_05_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_traffic_manager",
+        "tag": "package-2017-05"
       },
-      "output_dir": "management/azure_mgmt_web/lib",
-      "wrapper_filesOrDirs": [
-        "azure_mgmt_web.rb"
-      ]
+      "output_dir": "management/azure_mgmt_traffic_manager/lib/2017-05-01",
+      "generated_relative_base_directory": "2017-05-01",
+      "build_dir": "management/azure_mgmt_traffic_manager/lib/2017-05-01"
+    },
+    "azure_mgmt_traffic_manager_2017_03_01": {
+      "markdown": "specification/trafficmanager/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::TrafficManager::Api_2017_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_traffic_manager",
+        "tag": "package-2017-03"
+      },
+      "output_dir": "management/azure_mgmt_traffic_manager/lib/2017-03-01",
+      "generated_relative_base_directory": "2017-03-01",
+      "build_dir": "management/azure_mgmt_traffic_manager/lib/2017-03-01"
+    },
+    "azure_mgmt_traffic_manager_2015_11_01": {
+      "markdown": "specification/trafficmanager/resource-manager/readme.md",
+      "autorest_options": {
+        "namespace": "Azure::ARM::TrafficManager::Api_2015_11_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_traffic_manager",
+        "tag": "package-2015-11"
+      },
+      "output_dir": "management/azure_mgmt_traffic_manager/lib/2015-11-01",
+      "generated_relative_base_directory": "2015-11-01",
+      "build_dir": "management/azure_mgmt_traffic_manager/lib/2015-11-01"
+    },
+    "azure_mgmt_web_2015_08_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Web::Api_2015_08_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_web",
+        "input-file": [
+          "specification/web/resource-manager/Microsoft.CertificateRegistration/2015-08-01/AppServiceCertificateOrders.json"
+        ],
+        "title": "WebSiteManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_web/lib/2015-08-01",
+      "generated_relative_base_directory": "2015-08-01",
+      "build_dir": "management/azure_mgmt_web/lib/2015-08-01"
+    },
+    "azure_mgmt_web_2015_04_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Web::Api_2015_04_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_web",
+        "input-file": [
+          "specification/web/resource-manager/Microsoft.DomainRegistration/2015-04-01/Domains.json",
+          "specification/web/resource-manager/Microsoft.DomainRegistration/2015-04-01/TopLevelDomains.json"
+        ],
+        "title": "WebSiteManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_web/lib/2015-04-01",
+      "generated_relative_base_directory": "2015-04-01",
+      "build_dir": "management/azure_mgmt_web/lib/2015-04-01"
+    },
+    "azure_mgmt_web_2016_09_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Web::Api_2016_09_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_web",
+        "input-file": [
+          "specification/web/resource-manager/Microsoft.Web/2016-09-01/AppServiceEnvironments.json",
+          "specification/web/resource-manager/Microsoft.Web/2016-09-01/AppServicePlans.json"
+        ],
+        "title": "WebSiteManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_web/lib/2016-09-01",
+      "generated_relative_base_directory": "2016-09-01",
+      "build_dir": "management/azure_mgmt_web/lib/2016-09-01"
+    },
+    "azure_mgmt_web_2016_08_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Web::Api_2016_08_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_web",
+        "input-file": [
+          "specification/web/resource-manager/Microsoft.Web/2016-08-01/WebApps.json"
+        ],
+        "title": "WebSiteManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_web/lib/2016-08-01",
+      "generated_relative_base_directory": "2016-08-01",
+      "build_dir": "management/azure_mgmt_web/lib/2016-08-01"
+    },
+    "azure_mgmt_web_2016_03_01": {
+      "autorest_options": {
+        "namespace": "Azure::ARM::Web::Api_2016_03_01",
+        "package-version": "0.11.0",
+        "package-name": "azure_mgmt_web",
+        "input-file": [
+          "specification/web/resource-manager/Microsoft.Web/2016-03-01/Certificates.json",
+          "specification/web/resource-manager/Microsoft.Web/2016-03-01/DeletedWebApps.json",
+          "specification/web/resource-manager/Microsoft.Web/2016-03-01/Provider.json",
+          "specification/web/resource-manager/Microsoft.Web/2016-03-01/Recommendations.json",
+          "specification/web/resource-manager/Microsoft.Web/2016-03-01/ResourceProvider.json"
+        ],
+        "title": "WebSiteManagementClient"
+      },
+      "output_dir": "management/azure_mgmt_web/lib/2016-03-01",
+      "generated_relative_base_directory": "2016-03-01",
+      "build_dir": "management/azure_mgmt_web/lib/2016-03-01"
     }
   }
 }


### PR DESCRIPTION
Fully synced from azure-stack/config.json

Regarding https://github.com/Azure/azure-sdk-for-ruby/issues/904

Checklist:

- [x] Include all the azure_mgmt_* from `config.json`
- [x] Remove `debug`
- [x] Remvoe `verbose`
- [x] Remove `use`
- [x] Make sure the Multi-api `AutoRest.Ruby` generator has been released and that is being used here
- [x] Update all .gemspec to ignore `build.json` file and that'd not be shipped while bundling
- [x] Make sure not to touch profiles