### PR TITLE
Regen links

### DIFF
--- a/config.json
+++ b/config.json
@@ -317,8 +317,7 @@
       "markdown": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/current/specification/resources/resource-manager/readme.md",
       "namespace": "Azure::ARM::Links::Api_2016_09_01",
       "package-version": "0.11.0",
-      "tag": "package-links-2016-09",
-      "title": "LinksManagementClient"
+      "tag": "package-links-2016-09"
     }
   },
   "azure_mgmt_locks": {

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links.rb
@@ -21,7 +21,7 @@ require 'ms_rest_azure'
 
 module Azure::ARM::Links::Api_2016_09_01
   autoload :ResourceLinks,                                      '2016-09-01/generated/azure_mgmt_links/resource_links.rb'
-  autoload :LinksManagementClient,                              '2016-09-01/generated/azure_mgmt_links/links_management_client.rb'
+  autoload :ManagementLinkClient,                               '2016-09-01/generated/azure_mgmt_links/management_link_client.rb'
 
   module Models
     autoload :ResourceLink,                                       '2016-09-01/generated/azure_mgmt_links/models/resource_link.rb'

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/management_link_client.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/management_link_client.rb
@@ -7,7 +7,7 @@ module Azure::ARM::Links::Api_2016_09_01
   #
   # A service client - single point of access to the REST API.
   #
-  class LinksManagementClient < MsRestAzure::AzureServiceClient
+  class ManagementLinkClient < MsRestAzure::AzureServiceClient
     include MsRestAzure
     include MsRestAzure::Serialization
 
@@ -38,7 +38,7 @@ module Azure::ARM::Links::Api_2016_09_01
     attr_reader :resource_links
 
     #
-    # Creates initializes a new instance of the LinksManagementClient class.
+    # Creates initializes a new instance of the ManagementLinkClient class.
     # @param credentials [MsRest::ServiceClientCredentials] credentials to authorize HTTP requests made by the service client.
     # @param base_url [String] the base URI of the service.
     # @param options [Array] filters to be applied to the HTTP requests.

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link.rb
@@ -12,7 +12,6 @@ module Azure::ARM::Links::Api_2016_09_01
 
       include MsRestAzure
 
-      include MsRest::JSONable
       # @return [String] The fully qualified ID of the resource link.
       attr_accessor :id
 

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link_filter.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link_filter.rb
@@ -12,7 +12,6 @@ module Azure::ARM::Links::Api_2016_09_01
 
       include MsRestAzure
 
-      include MsRest::JSONable
       # @return [String] The ID of the target resource.
       attr_accessor :target_id
 

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link_properties.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/models/resource_link_properties.rb
@@ -12,7 +12,6 @@ module Azure::ARM::Links::Api_2016_09_01
 
       include MsRestAzure
 
-      include MsRest::JSONable
       # @return [String] The fully qualified ID of the source resource in the
       # link.
       attr_accessor :source_id

--- a/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/resource_links.rb
+++ b/management/azure_mgmt_links/lib/2016-09-01/generated/azure_mgmt_links/resource_links.rb
@@ -23,7 +23,7 @@ module Azure::ARM::Links::Api_2016_09_01
       @client = client
     end
 
-    # @return [LinksManagementClient] reference to the LinksManagementClient
+    # @return [ManagementLinkClient] reference to the ManagementLinkClient
     attr_reader :client
 
     #


### PR DESCRIPTION
Updating config.json to not overwrite title for links package. 
Also re-generating to accompany this change. 
I'll be regenerating all of the other gems with a specific commit hash from rest-api-specs repo and latest autorest, so no need to worry about generation of all for this pr.