### PR TITLE
Change Storage API Version in Azure Stack

### DIFF
--- a/azure_sdk/lib/v2017_03_09/modules/storage_profile_module.rb
+++ b/azure_sdk/lib/v2017_03_09/modules/storage_profile_module.rb
@@ -6,29 +6,38 @@ require 'azure_mgmt_storage'
 
 module Azure::Profiles::V2017_03_09
   module Storage::Mgmt
-    StorageAccounts = Azure::Storage::Mgmt::V2015_06_15::StorageAccounts
-    UsageOperations = Azure::Storage::Mgmt::V2015_06_15::UsageOperations
+    StorageAccounts = Azure::Storage::Mgmt::V2016_01_01::StorageAccounts
+    UsageOperations = Azure::Storage::Mgmt::V2016_01_01::UsageOperations
 
     module Models
-      StorageAccountListResult = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountListResult
-      StorageAccountCheckNameAvailabilityParameters = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountCheckNameAvailabilityParameters
-      StorageAccountUpdateParameters = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountUpdateParameters
-      StorageAccountCreateParameters = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountCreateParameters
-      StorageAccountRegenerateKeyParameters = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountRegenerateKeyParameters
-      CustomDomain = Azure::Storage::Mgmt::V2015_06_15::Models::CustomDomain
-      UsageName = Azure::Storage::Mgmt::V2015_06_15::Models::UsageName
-      StorageAccountKeys = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountKeys
-      Usage = Azure::Storage::Mgmt::V2015_06_15::Models::Usage
-      Endpoints = Azure::Storage::Mgmt::V2015_06_15::Models::Endpoints
-      UsageListResult = Azure::Storage::Mgmt::V2015_06_15::Models::UsageListResult
-      CheckNameAvailabilityResult = Azure::Storage::Mgmt::V2015_06_15::Models::CheckNameAvailabilityResult
-      Resource = Azure::Storage::Mgmt::V2015_06_15::Models::Resource
-      StorageAccount = Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccount
-      Reason = Azure::Storage::Mgmt::V2015_06_15::Models::Reason
-      AccountType = Azure::Storage::Mgmt::V2015_06_15::Models::AccountType
-      ProvisioningState = Azure::Storage::Mgmt::V2015_06_15::Models::ProvisioningState
-      AccountStatus = Azure::Storage::Mgmt::V2015_06_15::Models::AccountStatus
-      UsageUnit = Azure::Storage::Mgmt::V2015_06_15::Models::UsageUnit
+      StorageAccountCheckNameAvailabilityParameters = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountCheckNameAvailabilityParameters
+      StorageAccountKey = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountKey
+      Sku = Azure::Storage::Mgmt::V2016_01_01::Models::Sku
+      StorageAccountListResult = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountListResult
+      EncryptionService = Azure::Storage::Mgmt::V2016_01_01::Models::EncryptionService
+      StorageAccountListKeysResult = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountListKeysResult
+      Encryption = Azure::Storage::Mgmt::V2016_01_01::Models::Encryption
+      StorageAccountRegenerateKeyParameters = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountRegenerateKeyParameters
+      Endpoints = Azure::Storage::Mgmt::V2016_01_01::Models::Endpoints
+      StorageAccountUpdateParameters = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountUpdateParameters
+      CustomDomain = Azure::Storage::Mgmt::V2016_01_01::Models::CustomDomain
+      UsageName = Azure::Storage::Mgmt::V2016_01_01::Models::UsageName
+      StorageAccountCreateParameters = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountCreateParameters
+      Usage = Azure::Storage::Mgmt::V2016_01_01::Models::Usage
+      EncryptionServices = Azure::Storage::Mgmt::V2016_01_01::Models::EncryptionServices
+      UsageListResult = Azure::Storage::Mgmt::V2016_01_01::Models::UsageListResult
+      CheckNameAvailabilityResult = Azure::Storage::Mgmt::V2016_01_01::Models::CheckNameAvailabilityResult
+      Resource = Azure::Storage::Mgmt::V2016_01_01::Models::Resource
+      StorageAccount = Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccount
+      Reason = Azure::Storage::Mgmt::V2016_01_01::Models::Reason
+      SkuName = Azure::Storage::Mgmt::V2016_01_01::Models::SkuName
+      SkuTier = Azure::Storage::Mgmt::V2016_01_01::Models::SkuTier
+      AccessTier = Azure::Storage::Mgmt::V2016_01_01::Models::AccessTier
+      Kind = Azure::Storage::Mgmt::V2016_01_01::Models::Kind
+      ProvisioningState = Azure::Storage::Mgmt::V2016_01_01::Models::ProvisioningState
+      AccountStatus = Azure::Storage::Mgmt::V2016_01_01::Models::AccountStatus
+      KeyPermission = Azure::Storage::Mgmt::V2016_01_01::Models::KeyPermission
+      UsageUnit = Azure::Storage::Mgmt::V2016_01_01::Models::UsageUnit
     end
 
     #
@@ -40,7 +49,7 @@ module Azure::Profiles::V2017_03_09
       def initialize(configurable, base_url=nil, options=nil)
         @configurable, @base_url, @options = configurable, base_url, options
 
-        client_0 = Azure::Storage::Mgmt::V2015_06_15::StorageManagementClient.new(configurable.credentials, base_url, options)
+        client_0 = Azure::Storage::Mgmt::V2016_01_01::StorageManagementClient.new(configurable.credentials, base_url, options)
         if(client_0.respond_to?(:subscription_id))
           client_0.subscription_id = configurable.subscription_id
         end
@@ -51,62 +60,89 @@ module Azure::Profiles::V2017_03_09
       end
 
       class ModelClasses
-        def storage_account_list_result
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountListResult
-        end
         def storage_account_check_name_availability_parameters
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountCheckNameAvailabilityParameters
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountCheckNameAvailabilityParameters
         end
-        def storage_account_update_parameters
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountUpdateParameters
+        def storage_account_key
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountKey
         end
-        def storage_account_create_parameters
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountCreateParameters
+        def sku
+          Azure::Storage::Mgmt::V2016_01_01::Models::Sku
+        end
+        def storage_account_list_result
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountListResult
+        end
+        def encryption_service
+          Azure::Storage::Mgmt::V2016_01_01::Models::EncryptionService
+        end
+        def storage_account_list_keys_result
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountListKeysResult
+        end
+        def encryption
+          Azure::Storage::Mgmt::V2016_01_01::Models::Encryption
         end
         def storage_account_regenerate_key_parameters
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountRegenerateKeyParameters
-        end
-        def custom_domain
-          Azure::Storage::Mgmt::V2015_06_15::Models::CustomDomain
-        end
-        def usage_name
-          Azure::Storage::Mgmt::V2015_06_15::Models::UsageName
-        end
-        def storage_account_keys
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccountKeys
-        end
-        def usage
-          Azure::Storage::Mgmt::V2015_06_15::Models::Usage
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountRegenerateKeyParameters
         end
         def endpoints
-          Azure::Storage::Mgmt::V2015_06_15::Models::Endpoints
+          Azure::Storage::Mgmt::V2016_01_01::Models::Endpoints
+        end
+        def storage_account_update_parameters
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountUpdateParameters
+        end
+        def custom_domain
+          Azure::Storage::Mgmt::V2016_01_01::Models::CustomDomain
+        end
+        def usage_name
+          Azure::Storage::Mgmt::V2016_01_01::Models::UsageName
+        end
+        def storage_account_create_parameters
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccountCreateParameters
+        end
+        def usage
+          Azure::Storage::Mgmt::V2016_01_01::Models::Usage
+        end
+        def encryption_services
+          Azure::Storage::Mgmt::V2016_01_01::Models::EncryptionServices
         end
         def usage_list_result
-          Azure::Storage::Mgmt::V2015_06_15::Models::UsageListResult
+          Azure::Storage::Mgmt::V2016_01_01::Models::UsageListResult
         end
         def check_name_availability_result
-          Azure::Storage::Mgmt::V2015_06_15::Models::CheckNameAvailabilityResult
+          Azure::Storage::Mgmt::V2016_01_01::Models::CheckNameAvailabilityResult
         end
         def resource
-          Azure::Storage::Mgmt::V2015_06_15::Models::Resource
+          Azure::Storage::Mgmt::V2016_01_01::Models::Resource
         end
         def storage_account
-          Azure::Storage::Mgmt::V2015_06_15::Models::StorageAccount
+          Azure::Storage::Mgmt::V2016_01_01::Models::StorageAccount
         end
         def reason
-          Azure::Storage::Mgmt::V2015_06_15::Models::Reason
+          Azure::Storage::Mgmt::V2016_01_01::Models::Reason
         end
-        def account_type
-          Azure::Storage::Mgmt::V2015_06_15::Models::AccountType
+        def sku_name
+          Azure::Storage::Mgmt::V2016_01_01::Models::SkuName
+        end
+        def sku_tier
+          Azure::Storage::Mgmt::V2016_01_01::Models::SkuTier
+        end
+        def access_tier
+          Azure::Storage::Mgmt::V2016_01_01::Models::AccessTier
+        end
+        def kind
+          Azure::Storage::Mgmt::V2016_01_01::Models::Kind
         end
         def provisioning_state
-          Azure::Storage::Mgmt::V2015_06_15::Models::ProvisioningState
+          Azure::Storage::Mgmt::V2016_01_01::Models::ProvisioningState
         end
         def account_status
-          Azure::Storage::Mgmt::V2015_06_15::Models::AccountStatus
+          Azure::Storage::Mgmt::V2016_01_01::Models::AccountStatus
+        end
+        def key_permission
+          Azure::Storage::Mgmt::V2016_01_01::Models::KeyPermission
         end
         def usage_unit
-          Azure::Storage::Mgmt::V2015_06_15::Models::UsageUnit
+          Azure::Storage::Mgmt::V2016_01_01::Models::UsageUnit
         end
       end
     end

--- a/profile_specs/profiles.json
+++ b/profile_specs/profiles.json
@@ -5,7 +5,7 @@
             "name": "V2017_03_09",
             "resourceTypes": {
                 "Microsoft.Storage": {
-                    "2015-06-15": ["*"]
+                    "2016-01-01": ["*"]
                 },
                 "Microsoft.Network" : {
                     "2015-06-15": ["*"]


### PR DESCRIPTION
This is related to [Issue #1117](https://github.com/Azure/azure-sdk-for-ruby/issues/1117). This is a simple change where we need to change the Storage API version from 2015-06-15 to 2016-01-01.

@veronicagg @salameer Please review and approve