### PR TITLE
[AutoPR cognitiveservices/data-plane/SpellCheck/cognitiveservices/data-plane/LUIS/Authoring/cognitiveservices/data-plane/LUIS/Runtime] [Cognitive Services] unify client class names, folder cases.

### DIFF
--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/answer.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/answer.rb
@@ -27,7 +27,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Answer',
           type: {
@@ -35,7 +34,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'Answer',
             model_properties: {
               _type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: '_type',
                 type: {
@@ -43,7 +41,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               id: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'id',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/error.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/error.rb
@@ -47,7 +47,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Error',
           type: {
@@ -55,7 +54,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'Error',
             model_properties: {
               code: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'code',
                 default_value: 'None',
@@ -64,7 +62,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               sub_code: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'subCode',
@@ -73,7 +70,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               message: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'message',
                 type: {
@@ -81,7 +77,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               more_details: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'moreDetails',
@@ -90,7 +85,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               parameter: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'parameter',
@@ -99,7 +93,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               value: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'value',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/error_response.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/error_response.rb
@@ -30,7 +30,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'ErrorResponse',
           type: {
@@ -38,7 +37,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'ErrorResponse',
             model_properties: {
               _type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: '_type',
                 type: {
@@ -46,7 +44,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               id: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'id',
@@ -55,13 +52,11 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               errors: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'errors',
                 type: {
                   name: 'Sequence',
                   element: {
-                      client_side_validation: true,
                       required: false,
                       serialized_name: 'ErrorElementType',
                       type: {

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/identifiable.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/identifiable.rb
@@ -29,7 +29,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Identifiable',
           type: {
@@ -37,7 +36,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'Identifiable',
             model_properties: {
               _type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: '_type',
                 type: {
@@ -45,7 +43,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               id: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'id',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/response.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/response.rb
@@ -27,7 +27,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Response',
           type: {
@@ -35,7 +34,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'Response',
             model_properties: {
               _type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: '_type',
                 type: {
@@ -43,7 +41,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               id: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'id',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/response_base.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/response_base.rb
@@ -33,7 +33,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'ResponseBase',
           type: {

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spell_check.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spell_check.rb
@@ -30,7 +30,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'SpellCheck',
           type: {
@@ -38,7 +37,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'SpellCheck',
             model_properties: {
               _type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: '_type',
                 type: {
@@ -46,7 +44,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               id: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'id',
@@ -55,13 +52,11 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               flagged_tokens: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'flaggedTokens',
                 type: {
                   name: 'Sequence',
                   element: {
-                      client_side_validation: true,
                       required: false,
                       serialized_name: 'SpellingFlaggedTokenElementType',
                       type: {

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spelling_flagged_token.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spelling_flagged_token.rb
@@ -36,7 +36,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Spelling/FlaggedToken',
           type: {
@@ -44,7 +43,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'SpellingFlaggedToken',
             model_properties: {
               offset: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'offset',
                 type: {
@@ -52,7 +50,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               token: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'token',
                 type: {
@@ -60,7 +57,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               type: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'type',
                 default_value: 'UnknownToken',
@@ -69,14 +65,12 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               suggestions: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'suggestions',
                 type: {
                   name: 'Sequence',
                   element: {
-                      client_side_validation: true,
                       required: false,
                       serialized_name: 'SpellingTokenSuggestionElementType',
                       type: {
@@ -87,7 +81,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               ping_url_suffix: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'pingUrlSuffix',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spelling_token_suggestion.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/models/spelling_token_suggestion.rb
@@ -29,7 +29,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       #
       def self.mapper()
         {
-          client_side_validation: true,
           required: false,
           serialized_name: 'Spelling/TokenSuggestion',
           type: {
@@ -37,7 +36,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
             class_name: 'SpellingTokenSuggestion',
             model_properties: {
               suggestion: {
-                client_side_validation: true,
                 required: true,
                 serialized_name: 'suggestion',
                 type: {
@@ -45,7 +43,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               score: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'score',
@@ -54,7 +51,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
                 }
               },
               ping_url_suffix: {
-                client_side_validation: true,
                 required: false,
                 read_only: true,
                 serialized_name: 'pingUrlSuffix',

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/spell_check_client.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/spell_check_client.rb
@@ -97,9 +97,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       fail ArgumentError, 'path is nil' if path.nil?
 
       request_url = options[:base_url] || @base_url
-      if(!options[:headers].nil? && !options[:headers]['Content-Type'].nil?)
-        @request_headers['Content-Type'] = options[:headers]['Content-Type']
-      end
 
       request_headers = @request_headers
       request_headers.merge!({'accept-language' => @accept_language}) unless @accept_language.nil?
@@ -278,7 +275,7 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     # default is Proof. 1) Proof—Finds most spelling and grammar mistakes. 2)
     # Spell—Finds most spelling mistakes but does not find some of the grammar
     # errors that Proof catches (for example, capitalization and repeated words).
-    # Possible values include: 'Proof', 'Spell'
+    # Possible values include: 'proof', 'spell'
     # @param pre_context_text [String] A string that gives context to the text
     # string. For example, the text string petal is valid. However, if you set
     # preContextText to bike, the context changes and the text string becomes not
@@ -302,8 +299,8 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     #
     # @return [SpellCheck] operation results.
     #
-    def spell_checker(text, accept_language:nil, pragma:nil, user_agent:nil, client_id:nil, client_ip:nil, location:nil, action_type:nil, app_name:nil, country_code:nil, client_machine_name:nil, doc_id:nil, market:nil, session_id:nil, set_lang:nil, user_id:nil, mode:nil, pre_context_text:nil, post_context_text:nil, custom_headers:nil)
-      response = spell_checker_async(text, accept_language:accept_language, pragma:pragma, user_agent:user_agent, client_id:client_id, client_ip:client_ip, location:location, action_type:action_type, app_name:app_name, country_code:country_code, client_machine_name:client_machine_name, doc_id:doc_id, market:market, session_id:session_id, set_lang:set_lang, user_id:user_id, mode:mode, pre_context_text:pre_context_text, post_context_text:post_context_text, custom_headers:custom_headers).value!
+    def spell_checker(text, accept_language = nil, pragma = nil, user_agent = nil, client_id = nil, client_ip = nil, location = nil, action_type = nil, app_name = nil, country_code = nil, client_machine_name = nil, doc_id = nil, market = nil, session_id = nil, set_lang = nil, user_id = nil, mode = nil, pre_context_text = nil, post_context_text = nil, custom_headers = nil)
+      response = spell_checker_async(text, accept_language, pragma, user_agent, client_id, client_ip, location, action_type, app_name, country_code, client_machine_name, doc_id, market, session_id, set_lang, user_id, mode, pre_context_text, post_context_text, custom_headers).value!
       response.body unless response.nil?
     end
 
@@ -476,7 +473,7 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     # default is Proof. 1) Proof—Finds most spelling and grammar mistakes. 2)
     # Spell—Finds most spelling mistakes but does not find some of the grammar
     # errors that Proof catches (for example, capitalization and repeated words).
-    # Possible values include: 'Proof', 'Spell'
+    # Possible values include: 'proof', 'spell'
     # @param pre_context_text [String] A string that gives context to the text
     # string. For example, the text string petal is valid. However, if you set
     # preContextText to bike, the context changes and the text string becomes not
@@ -500,8 +497,8 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     #
     # @return [MsRestAzure::AzureOperationResponse] HTTP response information.
     #
-    def spell_checker_with_http_info(text, accept_language:nil, pragma:nil, user_agent:nil, client_id:nil, client_ip:nil, location:nil, action_type:nil, app_name:nil, country_code:nil, client_machine_name:nil, doc_id:nil, market:nil, session_id:nil, set_lang:nil, user_id:nil, mode:nil, pre_context_text:nil, post_context_text:nil, custom_headers:nil)
-      spell_checker_async(text, accept_language:accept_language, pragma:pragma, user_agent:user_agent, client_id:client_id, client_ip:client_ip, location:location, action_type:action_type, app_name:app_name, country_code:country_code, client_machine_name:client_machine_name, doc_id:doc_id, market:market, session_id:session_id, set_lang:set_lang, user_id:user_id, mode:mode, pre_context_text:pre_context_text, post_context_text:post_context_text, custom_headers:custom_headers).value!
+    def spell_checker_with_http_info(text, accept_language = nil, pragma = nil, user_agent = nil, client_id = nil, client_ip = nil, location = nil, action_type = nil, app_name = nil, country_code = nil, client_machine_name = nil, doc_id = nil, market = nil, session_id = nil, set_lang = nil, user_id = nil, mode = nil, pre_context_text = nil, post_context_text = nil, custom_headers = nil)
+      spell_checker_async(text, accept_language, pragma, user_agent, client_id, client_ip, location, action_type, app_name, country_code, client_machine_name, doc_id, market, session_id, set_lang, user_id, mode, pre_context_text, post_context_text, custom_headers).value!
     end
 
     #
@@ -673,7 +670,7 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     # default is Proof. 1) Proof—Finds most spelling and grammar mistakes. 2)
     # Spell—Finds most spelling mistakes but does not find some of the grammar
     # errors that Proof catches (for example, capitalization and repeated words).
-    # Possible values include: 'Proof', 'Spell'
+    # Possible values include: 'proof', 'spell'
     # @param pre_context_text [String] A string that gives context to the text
     # string. For example, the text string petal is valid. However, if you set
     # preContextText to bike, the context changes and the text string becomes not
@@ -697,13 +694,12 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     #
     # @return [Concurrent::Promise] Promise object which holds the HTTP response.
     #
-    def spell_checker_async(text, accept_language:nil, pragma:nil, user_agent:nil, client_id:nil, client_ip:nil, location:nil, action_type:nil, app_name:nil, country_code:nil, client_machine_name:nil, doc_id:nil, market:nil, session_id:nil, set_lang:nil, user_id:nil, mode:nil, pre_context_text:nil, post_context_text:nil, custom_headers:nil)
+    def spell_checker_async(text, accept_language = nil, pragma = nil, user_agent = nil, client_id = nil, client_ip = nil, location = nil, action_type = nil, app_name = nil, country_code = nil, client_machine_name = nil, doc_id = nil, market = nil, session_id = nil, set_lang = nil, user_id = nil, mode = nil, pre_context_text = nil, post_context_text = nil, custom_headers = nil)
       x_bing_apis_sdk = 'true'
       fail ArgumentError, 'text is nil' if text.nil?
 
 
       request_headers = {}
-      request_headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
       # Set Headers
       request_headers['x-ms-client-request-id'] = SecureRandom.uuid
@@ -714,14 +710,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
       request_headers['X-MSEdge-ClientID'] = client_id unless client_id.nil?
       request_headers['X-MSEdge-ClientIP'] = client_ip unless client_ip.nil?
       request_headers['X-Search-Location'] = location unless location.nil?
-
-      # Set Form Data
-      form_data = {}
-      form_data['Mode'] = mode.to_s unless mode.to_s.nil?
-      form_data['PreContextText'] = pre_context_text unless pre_context_text.nil?
-      form_data['PostContextText'] = post_context_text unless post_context_text.nil?
-      form_data['Text'] = text unless text.nil?
-
       path_template = 'spellcheck'
 
       request_url = @base_url || self.base_url
@@ -730,7 +718,6 @@ module Azure::CognitiveServices::SpellCheck::V1_0
           middlewares: [[MsRest::RetryPolicyMiddleware, times: 3, retry: 0.02], [:cookie_jar]],
           query_params: {'ActionType' => action_type,'AppName' => app_name,'cc' => country_code,'ClientMachineName' => client_machine_name,'DocId' => doc_id,'mkt' => market,'SessionId' => session_id,'SetLang' => set_lang,'UserId' => user_id},
           headers: request_headers.merge(custom_headers || {}),
-          body: URI.encode_www_form(form_data),
           base_url: request_url
       }
       promise = self.make_request_async(:post, path_template, options)
@@ -769,7 +756,9 @@ module Azure::CognitiveServices::SpellCheck::V1_0
     #
     def add_telemetry
         sdk_information = 'azure_cognitiveservices_spellcheck'
-        sdk_information = "#{sdk_information}/0.16.0"
+        if defined? Azure::CognitiveServices::SpellCheck::V1_0::VERSION
+          sdk_information = "#{sdk_information}/#{Azure::CognitiveServices::SpellCheck::V1_0::VERSION}"
+        end
         add_user_agent_information(sdk_information)
     end
   end

--- a/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/version.rb
+++ b/data/azure_cognitiveservices_spellcheck/lib/1.0/generated/azure_cognitiveservices_spellcheck/version.rb
@@ -4,13 +4,5 @@
 # regenerated.
 
 module Azure::CognitiveServices::SpellCheck::V1_0
-  module Models
-    #
-    # Defines values for Mode
-    #
-    module Mode
-      Proof = "proof"
-      Spell = "spell"
-    end
-  end
+    VERSION = '0.16.0'
 end


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3365