### PR TITLE
[AutoPR trafficmanager/resource-manager] Do not omit type and name while serializing the resource object.

### DIFF
--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/endpoint.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/endpoint.rb
@@ -90,7 +90,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -98,7 +97,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/heat_map_model.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/heat_map_model.rb
@@ -50,7 +50,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -58,7 +57,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/profile.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/profile.rb
@@ -65,7 +65,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -73,7 +72,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/proxy_resource.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/proxy_resource.rb
@@ -35,7 +35,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -43,7 +42,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/resource.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/resource.rb
@@ -45,7 +45,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -53,7 +52,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/tracked_resource.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/tracked_resource.rb
@@ -40,7 +40,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -48,7 +47,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/traffic_manager_geographic_hierarchy.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/traffic_manager_geographic_hierarchy.rb
@@ -39,7 +39,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -47,7 +46,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/user_metrics_model.rb
+++ b/management/azure_mgmt_traffic_manager/lib/2018-04-01/generated/azure_mgmt_traffic_manager/models/user_metrics_model.rb
@@ -37,7 +37,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               name: {
                 required: false,
-                read_only: true,
                 serialized_name: 'name',
                 type: {
                   name: 'String'
@@ -45,7 +44,6 @@ module Azure::TrafficManager::Mgmt::V2018_04_01
               },
               type: {
                 required: false,
-                read_only: true,
                 serialized_name: 'type',
                 type: {
                   name: 'String'


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4007