### PR TITLE
[AutoPR logic/resource-manager] Microsoft.Logic - Don't make ResourceReference id readonly

### DIFF
--- a/management/azure_mgmt_logic/lib/2018-07-01-preview/generated/azure_mgmt_logic/models/key_vault_reference.rb
+++ b/management/azure_mgmt_logic/lib/2018-07-01-preview/generated/azure_mgmt_logic/models/key_vault_reference.rb
@@ -27,7 +27,6 @@ module Azure::Logic::Mgmt::V2018_07_01_preview
             model_properties: {
               id: {
                 required: false,
-                read_only: true,
                 serialized_name: 'id',
                 type: {
                   name: 'String'

--- a/management/azure_mgmt_logic/lib/2018-07-01-preview/generated/azure_mgmt_logic/models/resource_reference.rb
+++ b/management/azure_mgmt_logic/lib/2018-07-01-preview/generated/azure_mgmt_logic/models/resource_reference.rb
@@ -36,7 +36,6 @@ module Azure::Logic::Mgmt::V2018_07_01_preview
             model_properties: {
               id: {
                 required: false,
-                read_only: true,
                 serialized_name: 'id',
                 type: {
                   name: 'String'


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4491