### PR TITLE
Don't ship the readme in the gem artifact

### DIFF
--- a/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
+++ b/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/Azure/azure-sdk-for-ruby/tree/master/management/azure_mgmt_resources'
   }
 
-  spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
+  spec.files         = Dir["LICENSE.txt", "lib/**/*"]
   spec.files.reject! { |fn| fn.include? "build.json" }
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Shave 4k off the install size. Same thing is done in the other Azure gems.