### PR TITLE
[AutoPR graphrbac/data-plane] graph: identifierUris should not be required

### DIFF
--- a/data/azure_graph_rbac/lib/1.6/generated/azure_graph_rbac/models/application_create_parameters.rb
+++ b/data/azure_graph_rbac/lib/1.6/generated/azure_graph_rbac/models/application_create_parameters.rb
@@ -320,7 +320,7 @@ module Azure::GraphRbac::V1_6
                 }
               },
               identifier_uris: {
-                required: true,
+                required: false,
                 serialized_name: 'identifierUris',
                 type: {
                   name: 'Sequence',


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5425