### PR TITLE
[AutoPR network/resource-manager] Swagger has to only enforce positive fileUploadLimitInMb values

### DIFF
--- a/management/azure_mgmt_network/lib/2018-12-01/generated/azure_mgmt_network/models/application_gateway_web_application_firewall_configuration.rb
+++ b/management/azure_mgmt_network/lib/2018-12-01/generated/azure_mgmt_network/models/application_gateway_web_application_firewall_configuration.rb
@@ -137,7 +137,6 @@ module Azure::Network::Mgmt::V2018_12_01
                 required: false,
                 serialized_name: 'fileUploadLimitInMb',
                 constraints: {
-                  InclusiveMaximum: 500,
                   InclusiveMinimum: 0
                 },
                 type: {


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5524