### PR TITLE
Added support for DomainCredentials for EventGrid domain credentials.

### DIFF
--- a/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/domain_credentials.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/domain_credentials.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+module MsRestAzure
+    #
+    # Class that enables access to Azure EventGrid domains.
+    #
+    class DomainCredentials < MsRest::ServiceClientCredentials
+
+      private
+
+      # @return [String] the domain key
+      attr_reader :domain_key
+
+      public
+
+      #
+      # Creates and initialize new instance of the DomainCredentials class.
+      # @param domain_key [String] domain key
+      def initialize(domain_key)
+        fail ArgumentError, 'Domain key cannot be nil' if domain_key.nil?
+        fail ArgumentError, 'Domain key must be of type string' if domain_key.class.to_s != 'String'
+        @domain_key = domain_key
+      end
+
+      def sign_request(request)
+        super(request)
+
+        if (request.respond_to?(:request_headers))
+          request.request_headers['aeg-sas-key'] = @domain_key
+        elsif request.respond_to?(:headers)
+          request.headers['aeg-sas-key'] = @domain_key
+        else
+          fail ArgumentError, 'Incorrect request object was provided'
+        end
+      end
+    end
+
+  end

--- a/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/topic_credentials.rb
+++ b/runtime/ms_rest_azure/lib/ms_rest_azure/credentials/topic_credentials.rb
@@ -4,7 +4,7 @@
 
 module MsRestAzure
   #
-  # Class that provides access to authentication token.
+  # Class that enables access to Azure EventGrid topics.
   #
   class TopicCredentials < MsRest::ServiceClientCredentials
 


### PR DESCRIPTION
Added a new DomainCredentials class for make it easier to supply EventGrid domain credentials. Event Grid domain is a recently introduced concept/resource and applications can publish events to an EventGrid domain for which an api key needs to be provided, and this newly introduced DomainCredentials class makes it easy to do so.