### PR TITLE
Don't add content encoding to the headers

### DIFF
--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -1369,17 +1369,14 @@ module Azure
       def call(method, uri, body=nil, headers=nil)
         # Synchronize body and header encoding; header['Content-Encoding'] takes precedence. 
         if headers && !body.nil?
-          if headers['Content-Encoding'].nil?
-            headers['Content-Encoding'] = body.encoding.to_s if body.respond_to? :encoding # String
-            headers['Content-Encoding'] = body.external_encoding.to_s if body.respond_to? :external_encoding # IO
-          else
+          if !headers['Content-Encoding'].nil?
             body.force_encoding(headers['Content-Encoding']) if body.respond_to? :force_encoding # String
             body.set_encoding(headers['Content-Encoding']) if body.respond_to? :set_encoding # IO
-          end
 
-          # Azure Storage Service expects content-encoding to be lowercase.
-          # Authentication will fail otherwise.
-          headers['Content-Encoding'] = headers['Content-Encoding'].downcase
+            # Azure Storage Service expects content-encoding to be lowercase.
+            # Authentication will fail otherwise.
+            headers['Content-Encoding'] = headers['Content-Encoding'].downcase
+          end
         end
 
         response = super


### PR DESCRIPTION
Fix #2720 

The content encoding will not be set automatically

so that we could possible leave it empty