### PR TITLE
Release ms_rest 0.7.5

### DIFF
--- a/runtime/ms_rest/lib/ms_rest/version.rb
+++ b/runtime/ms_rest/lib/ms_rest/version.rb
@@ -3,5 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 module MsRest
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end


### PR DESCRIPTION
ms_rest 0.7.4 -> 0.7.5
The real changes were already contained in another PR: #2733 

Release process: 
1. Bump the version in the `runtime/ms_rest/lib/ms_rest/version.rb`;
2. Run command `rake build` and `rake release` under path `runtime/ms_rest`;
3. Check https://rubygems.org/gems/ms_rest .