### PR TITLE
Fix #1271 - Produce usable GraphRbac client

### DIFF
--- a/data/azure_graph_rbac/lib/profiles/latest/graphrbac_latest_profile_client.rb
+++ b/data/azure_graph_rbac/lib/profiles/latest/graphrbac_latest_profile_client.rb
@@ -31,7 +31,18 @@ module Azure::GraphRbac::Profiles::Latest
     #   Also, base_url, active_directory_settings & options are optional.
     #
     def initialize(options = {})
+      options[:active_directory_settings] ||= default_active_directory_settings
       super(options)
+      @client_0.tenant_id = tenant_id if @client_0
+    end
+
+    private
+
+    def default_active_directory_settings
+      MsRestAzure::ActiveDirectoryServiceSettings.new.tap do |ad|
+        ad.authentication_endpoint = MsRestAzure::AzureEnvironments::AzureCloud.active_directory_endpoint_url
+        ad.token_audience = MsRestAzure::AzureEnvironments::AzureCloud.active_directory_graph_resource_id
+      end
     end
 
   end

--- a/data/azure_graph_rbac/lib/version.rb
+++ b/data/azure_graph_rbac/lib/version.rb
@@ -3,5 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 module Azure::GraphRbac
-    VERSION = '0.17.1'
+    VERSION = '0.17.2'
 end


### PR DESCRIPTION
There may be better ways to do this, but this issue has been around since Feb 2018. I'm open to suggestions/improvements, but this at least produces a usable client by setting only the normal options that the other clients require.