### PR TITLE
key_vault: Fix naming errors in create_certificate_async

### DIFF
--- a/data/azure_key_vault/lib/7.1/generated/azure_key_vault/key_vault_client.rb
+++ b/data/azure_key_vault/lib/7.1/generated/azure_key_vault/key_vault_client.rb
@@ -843,11 +843,11 @@ module Azure::KeyVault::V7_1
       fail ArgumentError, 'api_version is nil' if api_version.nil?
       fail ArgumentError, 'provider is nil' if provider.nil?
 
-      parameter = CertificateIssuerSetParameters.new
+      parameter = Models::CertificateIssuerSetParameters.new
       unless provider.nil? && credentials.nil? && organization_details.nil? && attributes.nil?
         parameter.provider = provider
         parameter.credentials = credentials
-        parameter.OrganizationDetails = organization_details
+        parameter.organization_details = organization_details
         parameter.attributes = attributes
       end
 

--- a/data/azure_key_vault/lib/7.1/generated/azure_key_vault/key_vault_client.rb
+++ b/data/azure_key_vault/lib/7.1/generated/azure_key_vault/key_vault_client.rb
@@ -1341,10 +1341,10 @@ module Azure::KeyVault::V7_1
       fail ArgumentError, "'certificate_name' should satisfy the constraint - 'Pattern': '^[0-9a-zA-Z-]+$'" if !certificate_name.nil? && certificate_name.match(Regexp.new('^^[0-9a-zA-Z-]+$$')).nil?
       fail ArgumentError, 'api_version is nil' if api_version.nil?
 
-      parameters = CertificateCreateParameters.new
+      parameters = Models::CertificateCreateParameters.new
       unless certificate_policy.nil? && certificate_attributes.nil? && tags.nil?
-        parameters.CertificatePolicy = certificate_policy
-        parameters.CertificateAttributes = certificate_attributes
+        parameters.certificate_policy = certificate_policy
+        parameters.certificate_attributes = certificate_attributes
         parameters.tags = tags
       end
 


### PR DESCRIPTION
`create_certificate_async` was failing because of naming of some types and
attributes. This caused certificate creation not to work using the API,
because it failed before even sending any request.

I'm not sure how the auto generation of this repo works, so I only fixed this 
for v7.1. It seems this bug also exists in other versions of the `azure_key_vault` 
API though.