### PR TITLE
use require_relative for relative paths

### DIFF
--- a/data/azure_cognitiveservices_anomalydetector/azure_cognitiveservices_anomalydetector.gemspec
+++ b/data/azure_cognitiveservices_anomalydetector/azure_cognitiveservices_anomalydetector.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_anomalydetector/lib/module_definition'
-require '../azure_cognitiveservices_anomalydetector/lib/version'
+require_relative '../azure_cognitiveservices_anomalydetector/lib/module_definition'
+require_relative '../azure_cognitiveservices_anomalydetector/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_anomalydetector'

--- a/data/azure_cognitiveservices_autosuggest/azure_cognitiveservices_autosuggest.gemspec
+++ b/data/azure_cognitiveservices_autosuggest/azure_cognitiveservices_autosuggest.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_autosuggest/lib/module_definition'
-require '../azure_cognitiveservices_autosuggest/lib/version'
+require_relative '../azure_cognitiveservices_autosuggest/lib/module_definition'
+require_relative '../azure_cognitiveservices_autosuggest/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_autosuggest'

--- a/data/azure_cognitiveservices_computervision/azure_cognitiveservices_computervision.gemspec
+++ b/data/azure_cognitiveservices_computervision/azure_cognitiveservices_computervision.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_computervision/lib/module_definition'
-require '../azure_cognitiveservices_computervision/lib/version'
+require_relative '../azure_cognitiveservices_computervision/lib/module_definition'
+require_relative '../azure_cognitiveservices_computervision/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_computervision'

--- a/data/azure_cognitiveservices_contentmoderator/azure_cognitiveservices_contentmoderator.gemspec
+++ b/data/azure_cognitiveservices_contentmoderator/azure_cognitiveservices_contentmoderator.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_contentmoderator/lib/module_definition'
-require '../azure_cognitiveservices_contentmoderator/lib/version'
+require_relative '../azure_cognitiveservices_contentmoderator/lib/module_definition'
+require_relative '../azure_cognitiveservices_contentmoderator/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_contentmoderator'

--- a/data/azure_cognitiveservices_customimagesearch/azure_cognitiveservices_customimagesearch.gemspec
+++ b/data/azure_cognitiveservices_customimagesearch/azure_cognitiveservices_customimagesearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_customimagesearch/lib/module_definition'
-require '../azure_cognitiveservices_customimagesearch/lib/version'
+require_relative '../azure_cognitiveservices_customimagesearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_customimagesearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_customimagesearch'

--- a/data/azure_cognitiveservices_customsearch/azure_cognitiveservices_customsearch.gemspec
+++ b/data/azure_cognitiveservices_customsearch/azure_cognitiveservices_customsearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_customsearch/lib/module_definition'
-require '../azure_cognitiveservices_customsearch/lib/version'
+require_relative '../azure_cognitiveservices_customsearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_customsearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_customsearch'

--- a/data/azure_cognitiveservices_customvisionprediction/azure_cognitiveservices_customvisionprediction.gemspec
+++ b/data/azure_cognitiveservices_customvisionprediction/azure_cognitiveservices_customvisionprediction.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_customvisionprediction/lib/module_definition'
-require '../azure_cognitiveservices_customvisionprediction/lib/version'
+require_relative '../azure_cognitiveservices_customvisionprediction/lib/module_definition'
+require_relative '../azure_cognitiveservices_customvisionprediction/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_customvisionprediction'

--- a/data/azure_cognitiveservices_customvisiontraining/azure_cognitiveservices_customvisiontraining.gemspec
+++ b/data/azure_cognitiveservices_customvisiontraining/azure_cognitiveservices_customvisiontraining.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_customvisiontraining/lib/module_definition'
-require '../azure_cognitiveservices_customvisiontraining/lib/version'
+require_relative '../azure_cognitiveservices_customvisiontraining/lib/module_definition'
+require_relative '../azure_cognitiveservices_customvisiontraining/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_customvisiontraining'

--- a/data/azure_cognitiveservices_entitysearch/azure_cognitiveservices_entitysearch.gemspec
+++ b/data/azure_cognitiveservices_entitysearch/azure_cognitiveservices_entitysearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_entitysearch/lib/module_definition'
-require '../azure_cognitiveservices_entitysearch/lib/version'
+require_relative '../azure_cognitiveservices_entitysearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_entitysearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_entitysearch'

--- a/data/azure_cognitiveservices_face/azure_cognitiveservices_face.gemspec
+++ b/data/azure_cognitiveservices_face/azure_cognitiveservices_face.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_face/lib/module_definition'
-require '../azure_cognitiveservices_face/lib/version'
+require_relative '../azure_cognitiveservices_face/lib/module_definition'
+require_relative '../azure_cognitiveservices_face/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_face'

--- a/data/azure_cognitiveservices_formrecognizer/azure_cognitiveservices_formrecognizer.gemspec
+++ b/data/azure_cognitiveservices_formrecognizer/azure_cognitiveservices_formrecognizer.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_formrecognizer/lib/module_definition'
-require '../azure_cognitiveservices_formrecognizer/lib/version'
+require_relative '../azure_cognitiveservices_formrecognizer/lib/module_definition'
+require_relative '../azure_cognitiveservices_formrecognizer/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_formrecognizer'

--- a/data/azure_cognitiveservices_imagesearch/azure_cognitiveservices_imagesearch.gemspec
+++ b/data/azure_cognitiveservices_imagesearch/azure_cognitiveservices_imagesearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_imagesearch/lib/module_definition'
-require '../azure_cognitiveservices_imagesearch/lib/version'
+require_relative '../azure_cognitiveservices_imagesearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_imagesearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_imagesearch'

--- a/data/azure_cognitiveservices_localsearch/azure_cognitiveservices_localsearch.gemspec
+++ b/data/azure_cognitiveservices_localsearch/azure_cognitiveservices_localsearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_localsearch/lib/module_definition'
-require '../azure_cognitiveservices_localsearch/lib/version'
+require_relative '../azure_cognitiveservices_localsearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_localsearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_localsearch'

--- a/data/azure_cognitiveservices_luisauthoring/azure_cognitiveservices_luisauthoring.gemspec
+++ b/data/azure_cognitiveservices_luisauthoring/azure_cognitiveservices_luisauthoring.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_luisauthoring/lib/module_definition'
-require '../azure_cognitiveservices_luisauthoring/lib/version'
+require_relative '../azure_cognitiveservices_luisauthoring/lib/module_definition'
+require_relative '../azure_cognitiveservices_luisauthoring/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_luisauthoring'

--- a/data/azure_cognitiveservices_luisruntime/azure_cognitiveservices_luisruntime.gemspec
+++ b/data/azure_cognitiveservices_luisruntime/azure_cognitiveservices_luisruntime.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_luisruntime/lib/module_definition'
-require '../azure_cognitiveservices_luisruntime/lib/version'
+require_relative '../azure_cognitiveservices_luisruntime/lib/module_definition'
+require_relative '../azure_cognitiveservices_luisruntime/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_luisruntime'

--- a/data/azure_cognitiveservices_newssearch/azure_cognitiveservices_newssearch.gemspec
+++ b/data/azure_cognitiveservices_newssearch/azure_cognitiveservices_newssearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_newssearch/lib/module_definition'
-require '../azure_cognitiveservices_newssearch/lib/version'
+require_relative '../azure_cognitiveservices_newssearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_newssearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_newssearch'

--- a/data/azure_cognitiveservices_personalizer/azure_cognitiveservices_personalizer.gemspec
+++ b/data/azure_cognitiveservices_personalizer/azure_cognitiveservices_personalizer.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_personalizer/lib/module_definition'
-require '../azure_cognitiveservices_personalizer/lib/version'
+require_relative '../azure_cognitiveservices_personalizer/lib/module_definition'
+require_relative '../azure_cognitiveservices_personalizer/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_personalizer'

--- a/data/azure_cognitiveservices_qnamaker/azure_cognitiveservices_qnamaker.gemspec
+++ b/data/azure_cognitiveservices_qnamaker/azure_cognitiveservices_qnamaker.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_qnamaker/lib/module_definition'
-require '../azure_cognitiveservices_qnamaker/lib/version'
+require_relative '../azure_cognitiveservices_qnamaker/lib/module_definition'
+require_relative '../azure_cognitiveservices_qnamaker/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_qnamaker'

--- a/data/azure_cognitiveservices_qnamakerruntime/azure_cognitiveservices_qnamakerruntime.gemspec
+++ b/data/azure_cognitiveservices_qnamakerruntime/azure_cognitiveservices_qnamakerruntime.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_qnamakerruntime/lib/module_definition'
-require '../azure_cognitiveservices_qnamakerruntime/lib/version'
+require_relative '../azure_cognitiveservices_qnamakerruntime/lib/module_definition'
+require_relative '../azure_cognitiveservices_qnamakerruntime/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_qnamakerruntime'

--- a/data/azure_cognitiveservices_spellcheck/azure_cognitiveservices_spellcheck.gemspec
+++ b/data/azure_cognitiveservices_spellcheck/azure_cognitiveservices_spellcheck.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_spellcheck/lib/module_definition'
-require '../azure_cognitiveservices_spellcheck/lib/version'
+require_relative '../azure_cognitiveservices_spellcheck/lib/module_definition'
+require_relative '../azure_cognitiveservices_spellcheck/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_spellcheck'

--- a/data/azure_cognitiveservices_textanalytics/azure_cognitiveservices_textanalytics.gemspec
+++ b/data/azure_cognitiveservices_textanalytics/azure_cognitiveservices_textanalytics.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_textanalytics/lib/module_definition'
-require '../azure_cognitiveservices_textanalytics/lib/version'
+require_relative '../azure_cognitiveservices_textanalytics/lib/module_definition'
+require_relative '../azure_cognitiveservices_textanalytics/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_textanalytics'

--- a/data/azure_cognitiveservices_videosearch/azure_cognitiveservices_videosearch.gemspec
+++ b/data/azure_cognitiveservices_videosearch/azure_cognitiveservices_videosearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_videosearch/lib/module_definition'
-require '../azure_cognitiveservices_videosearch/lib/version'
+require_relative '../azure_cognitiveservices_videosearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_videosearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_videosearch'

--- a/data/azure_cognitiveservices_visualsearch/azure_cognitiveservices_visualsearch.gemspec
+++ b/data/azure_cognitiveservices_visualsearch/azure_cognitiveservices_visualsearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_visualsearch/lib/module_definition'
-require '../azure_cognitiveservices_visualsearch/lib/version'
+require_relative '../azure_cognitiveservices_visualsearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_visualsearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_visualsearch'

--- a/data/azure_cognitiveservices_websearch/azure_cognitiveservices_websearch.gemspec
+++ b/data/azure_cognitiveservices_websearch/azure_cognitiveservices_websearch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_cognitiveservices_websearch/lib/module_definition'
-require '../azure_cognitiveservices_websearch/lib/version'
+require_relative '../azure_cognitiveservices_websearch/lib/module_definition'
+require_relative '../azure_cognitiveservices_websearch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_cognitiveservices_websearch'

--- a/data/azure_event_grid/azure_event_grid.gemspec
+++ b/data/azure_event_grid/azure_event_grid.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_event_grid/lib/module_definition'
-require '../azure_event_grid/lib/version'
+require_relative '../azure_event_grid/lib/module_definition'
+require_relative '../azure_event_grid/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_event_grid'

--- a/data/azure_graph_rbac/azure_graph_rbac.gemspec
+++ b/data/azure_graph_rbac/azure_graph_rbac.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_graph_rbac/lib/module_definition'
-require '../azure_graph_rbac/lib/version'
+require_relative '../azure_graph_rbac/lib/module_definition'
+require_relative '../azure_graph_rbac/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_graph_rbac'

--- a/data/azure_key_vault/azure_key_vault.gemspec
+++ b/data/azure_key_vault/azure_key_vault.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_key_vault/lib/module_definition'
-require '../azure_key_vault/lib/version'
+require_relative '../azure_key_vault/lib/module_definition'
+require_relative '../azure_key_vault/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_key_vault'

--- a/data/azure_service_fabric/azure_service_fabric.gemspec
+++ b/data/azure_service_fabric/azure_service_fabric.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_service_fabric/lib/module_definition'
-require '../azure_service_fabric/lib/version'
+require_relative '../azure_service_fabric/lib/module_definition'
+require_relative '../azure_service_fabric/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_service_fabric'

--- a/management/azure_mgmt_adhybridhealth_service/azure_mgmt_adhybridhealth_service.gemspec
+++ b/management/azure_mgmt_adhybridhealth_service/azure_mgmt_adhybridhealth_service.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_adhybridhealth_service/lib/module_definition'
-require '../azure_mgmt_adhybridhealth_service/lib/version'
+require_relative '../azure_mgmt_adhybridhealth_service/lib/module_definition'
+require_relative '../azure_mgmt_adhybridhealth_service/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_adhybridhealth_service'

--- a/management/azure_mgmt_advisor/azure_mgmt_advisor.gemspec
+++ b/management/azure_mgmt_advisor/azure_mgmt_advisor.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_advisor/lib/module_definition'
-require '../azure_mgmt_advisor/lib/version'
+require_relative '../azure_mgmt_advisor/lib/module_definition'
+require_relative '../azure_mgmt_advisor/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_advisor'

--- a/management/azure_mgmt_alerts_management/azure_mgmt_alerts_management.gemspec
+++ b/management/azure_mgmt_alerts_management/azure_mgmt_alerts_management.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_alerts_management/lib/module_definition'
-require '../azure_mgmt_alerts_management/lib/version'
+require_relative '../azure_mgmt_alerts_management/lib/module_definition'
+require_relative '../azure_mgmt_alerts_management/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_alerts_management'

--- a/management/azure_mgmt_analysis_services/azure_mgmt_analysis_services.gemspec
+++ b/management/azure_mgmt_analysis_services/azure_mgmt_analysis_services.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_analysis_services/lib/module_definition'
-require '../azure_mgmt_analysis_services/lib/version'
+require_relative '../azure_mgmt_analysis_services/lib/module_definition'
+require_relative '../azure_mgmt_analysis_services/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_analysis_services'

--- a/management/azure_mgmt_api_management/azure_mgmt_api_management.gemspec
+++ b/management/azure_mgmt_api_management/azure_mgmt_api_management.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_api_management/lib/module_definition'
-require '../azure_mgmt_api_management/lib/version'
+require_relative '../azure_mgmt_api_management/lib/module_definition'
+require_relative '../azure_mgmt_api_management/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_api_management'

--- a/management/azure_mgmt_appconfiguration/azure_mgmt_appconfiguration.gemspec
+++ b/management/azure_mgmt_appconfiguration/azure_mgmt_appconfiguration.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_appconfiguration/lib/module_definition'
-require '../azure_mgmt_appconfiguration/lib/version'
+require_relative '../azure_mgmt_appconfiguration/lib/module_definition'
+require_relative '../azure_mgmt_appconfiguration/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_appconfiguration'

--- a/management/azure_mgmt_attestation/azure_mgmt_attestation.gemspec
+++ b/management/azure_mgmt_attestation/azure_mgmt_attestation.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_attestation/lib/module_definition'
-require '../azure_mgmt_attestation/lib/version'
+require_relative '../azure_mgmt_attestation/lib/module_definition'
+require_relative '../azure_mgmt_attestation/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_attestation'

--- a/management/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
+++ b/management/azure_mgmt_authorization/azure_mgmt_authorization.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_authorization/lib/module_definition'
-require '../azure_mgmt_authorization/lib/version'
+require_relative '../azure_mgmt_authorization/lib/module_definition'
+require_relative '../azure_mgmt_authorization/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_authorization'

--- a/management/azure_mgmt_automanage/azure_mgmt_automanage.gemspec
+++ b/management/azure_mgmt_automanage/azure_mgmt_automanage.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_automanage/lib/module_definition'
-require '../azure_mgmt_automanage/lib/version'
+require_relative '../azure_mgmt_automanage/lib/module_definition'
+require_relative '../azure_mgmt_automanage/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_automanage'

--- a/management/azure_mgmt_automation/azure_mgmt_automation.gemspec
+++ b/management/azure_mgmt_automation/azure_mgmt_automation.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_automation/lib/module_definition'
-require '../azure_mgmt_automation/lib/version'
+require_relative '../azure_mgmt_automation/lib/module_definition'
+require_relative '../azure_mgmt_automation/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_automation'

--- a/management/azure_mgmt_azurestack/azure_mgmt_azurestack.gemspec
+++ b/management/azure_mgmt_azurestack/azure_mgmt_azurestack.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_azurestack/lib/module_definition'
-require '../azure_mgmt_azurestack/lib/version'
+require_relative '../azure_mgmt_azurestack/lib/module_definition'
+require_relative '../azure_mgmt_azurestack/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_azurestack'

--- a/management/azure_mgmt_azurestack_hci/azure_mgmt_azurestack_hci.gemspec
+++ b/management/azure_mgmt_azurestack_hci/azure_mgmt_azurestack_hci.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_azurestack_hci/lib/module_definition'
-require '../azure_mgmt_azurestack_hci/lib/version'
+require_relative '../azure_mgmt_azurestack_hci/lib/module_definition'
+require_relative '../azure_mgmt_azurestack_hci/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_azurestack_hci'

--- a/management/azure_mgmt_batch/azure_mgmt_batch.gemspec
+++ b/management/azure_mgmt_batch/azure_mgmt_batch.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_batch/lib/module_definition'
-require '../azure_mgmt_batch/lib/version'
+require_relative '../azure_mgmt_batch/lib/module_definition'
+require_relative '../azure_mgmt_batch/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_batch'

--- a/management/azure_mgmt_batchai/azure_mgmt_batchai.gemspec
+++ b/management/azure_mgmt_batchai/azure_mgmt_batchai.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_batchai/lib/module_definition'
-require '../azure_mgmt_batchai/lib/version'
+require_relative '../azure_mgmt_batchai/lib/module_definition'
+require_relative '../azure_mgmt_batchai/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_batchai'

--- a/management/azure_mgmt_billing/azure_mgmt_billing.gemspec
+++ b/management/azure_mgmt_billing/azure_mgmt_billing.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_billing/lib/module_definition'
-require '../azure_mgmt_billing/lib/version'
+require_relative '../azure_mgmt_billing/lib/module_definition'
+require_relative '../azure_mgmt_billing/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_billing'

--- a/management/azure_mgmt_bot_service/azure_mgmt_bot_service.gemspec
+++ b/management/azure_mgmt_bot_service/azure_mgmt_bot_service.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_bot_service/lib/module_definition'
-require '../azure_mgmt_bot_service/lib/version'
+require_relative '../azure_mgmt_bot_service/lib/module_definition'
+require_relative '../azure_mgmt_bot_service/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_bot_service'

--- a/management/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
+++ b/management/azure_mgmt_cdn/azure_mgmt_cdn.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_cdn/lib/module_definition'
-require '../azure_mgmt_cdn/lib/version'
+require_relative '../azure_mgmt_cdn/lib/module_definition'
+require_relative '../azure_mgmt_cdn/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_cdn'

--- a/management/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
+++ b/management/azure_mgmt_cognitive_services/azure_mgmt_cognitive_services.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_cognitive_services/lib/module_definition'
-require '../azure_mgmt_cognitive_services/lib/version'
+require_relative '../azure_mgmt_cognitive_services/lib/module_definition'
+require_relative '../azure_mgmt_cognitive_services/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_cognitive_services'

--- a/management/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
+++ b/management/azure_mgmt_commerce/azure_mgmt_commerce.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_commerce/lib/module_definition'
-require '../azure_mgmt_commerce/lib/version'
+require_relative '../azure_mgmt_commerce/lib/module_definition'
+require_relative '../azure_mgmt_commerce/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_commerce'

--- a/management/azure_mgmt_compute/azure_mgmt_compute.gemspec
+++ b/management/azure_mgmt_compute/azure_mgmt_compute.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_compute/lib/module_definition'
-require '../azure_mgmt_compute/lib/version'
+require_relative '../azure_mgmt_compute/lib/module_definition'
+require_relative '../azure_mgmt_compute/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_compute'

--- a/management/azure_mgmt_confluent/azure_mgmt_confluent.gemspec
+++ b/management/azure_mgmt_confluent/azure_mgmt_confluent.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_confluent/lib/module_definition'
-require '../azure_mgmt_confluent/lib/version'
+require_relative '../azure_mgmt_confluent/lib/module_definition'
+require_relative '../azure_mgmt_confluent/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_confluent'

--- a/management/azure_mgmt_consumption/azure_mgmt_consumption.gemspec
+++ b/management/azure_mgmt_consumption/azure_mgmt_consumption.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_consumption/lib/module_definition'
-require '../azure_mgmt_consumption/lib/version'
+require_relative '../azure_mgmt_consumption/lib/module_definition'
+require_relative '../azure_mgmt_consumption/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_consumption'

--- a/management/azure_mgmt_container_instance/azure_mgmt_container_instance.gemspec
+++ b/management/azure_mgmt_container_instance/azure_mgmt_container_instance.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_container_instance/lib/module_definition'
-require '../azure_mgmt_container_instance/lib/version'
+require_relative '../azure_mgmt_container_instance/lib/module_definition'
+require_relative '../azure_mgmt_container_instance/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_container_instance'

--- a/management/azure_mgmt_container_registry/azure_mgmt_container_registry.gemspec
+++ b/management/azure_mgmt_container_registry/azure_mgmt_container_registry.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_container_registry/lib/module_definition'
-require '../azure_mgmt_container_registry/lib/version'
+require_relative '../azure_mgmt_container_registry/lib/module_definition'
+require_relative '../azure_mgmt_container_registry/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_container_registry'

--- a/management/azure_mgmt_container_service/azure_mgmt_container_service.gemspec
+++ b/management/azure_mgmt_container_service/azure_mgmt_container_service.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_container_service/lib/module_definition'
-require '../azure_mgmt_container_service/lib/version'
+require_relative '../azure_mgmt_container_service/lib/module_definition'
+require_relative '../azure_mgmt_container_service/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_container_service'

--- a/management/azure_mgmt_cosmosdb/azure_mgmt_cosmosdb.gemspec
+++ b/management/azure_mgmt_cosmosdb/azure_mgmt_cosmosdb.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_cosmosdb/lib/module_definition'
-require '../azure_mgmt_cosmosdb/lib/version'
+require_relative '../azure_mgmt_cosmosdb/lib/module_definition'
+require_relative '../azure_mgmt_cosmosdb/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_cosmosdb'

--- a/management/azure_mgmt_cost_management/azure_mgmt_cost_management.gemspec
+++ b/management/azure_mgmt_cost_management/azure_mgmt_cost_management.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_cost_management/lib/module_definition'
-require '../azure_mgmt_cost_management/lib/version'
+require_relative '../azure_mgmt_cost_management/lib/module_definition'
+require_relative '../azure_mgmt_cost_management/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_cost_management'

--- a/management/azure_mgmt_customer_insights/azure_mgmt_customer_insights.gemspec
+++ b/management/azure_mgmt_customer_insights/azure_mgmt_customer_insights.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_customer_insights/lib/module_definition'
-require '../azure_mgmt_customer_insights/lib/version'
+require_relative '../azure_mgmt_customer_insights/lib/module_definition'
+require_relative '../azure_mgmt_customer_insights/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_customer_insights'

--- a/management/azure_mgmt_data_factory/azure_mgmt_data_factory.gemspec
+++ b/management/azure_mgmt_data_factory/azure_mgmt_data_factory.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_data_factory/lib/module_definition'
-require '../azure_mgmt_data_factory/lib/version'
+require_relative '../azure_mgmt_data_factory/lib/module_definition'
+require_relative '../azure_mgmt_data_factory/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_data_factory'

--- a/management/azure_mgmt_data_migration/azure_mgmt_data_migration.gemspec
+++ b/management/azure_mgmt_data_migration/azure_mgmt_data_migration.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_data_migration/lib/module_definition'
-require '../azure_mgmt_data_migration/lib/version'
+require_relative '../azure_mgmt_data_migration/lib/module_definition'
+require_relative '../azure_mgmt_data_migration/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_data_migration'

--- a/management/azure_mgmt_databox/azure_mgmt_databox.gemspec
+++ b/management/azure_mgmt_databox/azure_mgmt_databox.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_databox/lib/module_definition'
-require '../azure_mgmt_databox/lib/version'
+require_relative '../azure_mgmt_databox/lib/module_definition'
+require_relative '../azure_mgmt_databox/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_databox'

--- a/management/azure_mgmt_databoxedge/azure_mgmt_databoxedge.gemspec
+++ b/management/azure_mgmt_databoxedge/azure_mgmt_databoxedge.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_databoxedge/lib/module_definition'
-require '../azure_mgmt_databoxedge/lib/version'
+require_relative '../azure_mgmt_databoxedge/lib/module_definition'
+require_relative '../azure_mgmt_databoxedge/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_databoxedge'

--- a/management/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
+++ b/management/azure_mgmt_datalake_analytics/azure_mgmt_datalake_analytics.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_datalake_analytics/lib/module_definition'
-require '../azure_mgmt_datalake_analytics/lib/version'
+require_relative '../azure_mgmt_datalake_analytics/lib/module_definition'
+require_relative '../azure_mgmt_datalake_analytics/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_datalake_analytics'

--- a/management/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
+++ b/management/azure_mgmt_datalake_store/azure_mgmt_datalake_store.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_datalake_store/lib/module_definition'
-require '../azure_mgmt_datalake_store/lib/version'
+require_relative '../azure_mgmt_datalake_store/lib/module_definition'
+require_relative '../azure_mgmt_datalake_store/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_datalake_store'

--- a/management/azure_mgmt_datashare/azure_mgmt_datashare.gemspec
+++ b/management/azure_mgmt_datashare/azure_mgmt_datashare.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_datashare/lib/module_definition'
-require '../azure_mgmt_datashare/lib/version'
+require_relative '../azure_mgmt_datashare/lib/module_definition'
+require_relative '../azure_mgmt_datashare/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_datashare'

--- a/management/azure_mgmt_deployment_manager/azure_mgmt_deployment_manager.gemspec
+++ b/management/azure_mgmt_deployment_manager/azure_mgmt_deployment_manager.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_deployment_manager/lib/module_definition'
-require '../azure_mgmt_deployment_manager/lib/version'
+require_relative '../azure_mgmt_deployment_manager/lib/module_definition'
+require_relative '../azure_mgmt_deployment_manager/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_deployment_manager'

--- a/management/azure_mgmt_dev_spaces/azure_mgmt_dev_spaces.gemspec
+++ b/management/azure_mgmt_dev_spaces/azure_mgmt_dev_spaces.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_dev_spaces/lib/module_definition'
-require '../azure_mgmt_dev_spaces/lib/version'
+require_relative '../azure_mgmt_dev_spaces/lib/module_definition'
+require_relative '../azure_mgmt_dev_spaces/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_dev_spaces'

--- a/management/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
+++ b/management/azure_mgmt_devtestlabs/azure_mgmt_devtestlabs.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_devtestlabs/lib/module_definition'
-require '../azure_mgmt_devtestlabs/lib/version'
+require_relative '../azure_mgmt_devtestlabs/lib/module_definition'
+require_relative '../azure_mgmt_devtestlabs/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_devtestlabs'

--- a/management/azure_mgmt_digitaltwins/azure_mgmt_digitaltwins.gemspec
+++ b/management/azure_mgmt_digitaltwins/azure_mgmt_digitaltwins.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_digitaltwins/lib/module_definition'
-require '../azure_mgmt_digitaltwins/lib/version'
+require_relative '../azure_mgmt_digitaltwins/lib/module_definition'
+require_relative '../azure_mgmt_digitaltwins/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_digitaltwins'

--- a/management/azure_mgmt_dns/azure_mgmt_dns.gemspec
+++ b/management/azure_mgmt_dns/azure_mgmt_dns.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_dns/lib/module_definition'
-require '../azure_mgmt_dns/lib/version'
+require_relative '../azure_mgmt_dns/lib/module_definition'
+require_relative '../azure_mgmt_dns/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_dns'

--- a/management/azure_mgmt_edgegateway/azure_mgmt_edgegateway.gemspec
+++ b/management/azure_mgmt_edgegateway/azure_mgmt_edgegateway.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_edgegateway/lib/module_definition'
-require '../azure_mgmt_edgegateway/lib/version'
+require_relative '../azure_mgmt_edgegateway/lib/module_definition'
+require_relative '../azure_mgmt_edgegateway/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_edgegateway'

--- a/management/azure_mgmt_event_grid/azure_mgmt_event_grid.gemspec
+++ b/management/azure_mgmt_event_grid/azure_mgmt_event_grid.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_event_grid/lib/module_definition'
-require '../azure_mgmt_event_grid/lib/version'
+require_relative '../azure_mgmt_event_grid/lib/module_definition'
+require_relative '../azure_mgmt_event_grid/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_event_grid'

--- a/management/azure_mgmt_event_hub/azure_mgmt_event_hub.gemspec
+++ b/management/azure_mgmt_event_hub/azure_mgmt_event_hub.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_event_hub/lib/module_definition'
-require '../azure_mgmt_event_hub/lib/version'
+require_relative '../azure_mgmt_event_hub/lib/module_definition'
+require_relative '../azure_mgmt_event_hub/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_event_hub'

--- a/management/azure_mgmt_features/azure_mgmt_features.gemspec
+++ b/management/azure_mgmt_features/azure_mgmt_features.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_features/lib/module_definition'
-require '../azure_mgmt_features/lib/version'
+require_relative '../azure_mgmt_features/lib/module_definition'
+require_relative '../azure_mgmt_features/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_features'

--- a/management/azure_mgmt_hanaonazure/azure_mgmt_hanaonazure.gemspec
+++ b/management/azure_mgmt_hanaonazure/azure_mgmt_hanaonazure.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_hanaonazure/lib/module_definition'
-require '../azure_mgmt_hanaonazure/lib/version'
+require_relative '../azure_mgmt_hanaonazure/lib/module_definition'
+require_relative '../azure_mgmt_hanaonazure/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_hanaonazure'

--- a/management/azure_mgmt_hdinsight/azure_mgmt_hdinsight.gemspec
+++ b/management/azure_mgmt_hdinsight/azure_mgmt_hdinsight.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_hdinsight/lib/module_definition'
-require '../azure_mgmt_hdinsight/lib/version'
+require_relative '../azure_mgmt_hdinsight/lib/module_definition'
+require_relative '../azure_mgmt_hdinsight/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_hdinsight'

--- a/management/azure_mgmt_healthcare_apis/azure_mgmt_healthcare_apis.gemspec
+++ b/management/azure_mgmt_healthcare_apis/azure_mgmt_healthcare_apis.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_healthcare_apis/lib/module_definition'
-require '../azure_mgmt_healthcare_apis/lib/version'
+require_relative '../azure_mgmt_healthcare_apis/lib/module_definition'
+require_relative '../azure_mgmt_healthcare_apis/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_healthcare_apis'

--- a/management/azure_mgmt_hybrid_compute/azure_mgmt_hybrid_compute.gemspec
+++ b/management/azure_mgmt_hybrid_compute/azure_mgmt_hybrid_compute.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_hybrid_compute/lib/module_definition'
-require '../azure_mgmt_hybrid_compute/lib/version'
+require_relative '../azure_mgmt_hybrid_compute/lib/module_definition'
+require_relative '../azure_mgmt_hybrid_compute/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_hybrid_compute'

--- a/management/azure_mgmt_import_export/azure_mgmt_import_export.gemspec
+++ b/management/azure_mgmt_import_export/azure_mgmt_import_export.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_import_export/lib/module_definition'
-require '../azure_mgmt_import_export/lib/version'
+require_relative '../azure_mgmt_import_export/lib/module_definition'
+require_relative '../azure_mgmt_import_export/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_import_export'

--- a/management/azure_mgmt_iot_central/azure_mgmt_iot_central.gemspec
+++ b/management/azure_mgmt_iot_central/azure_mgmt_iot_central.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_iot_central/lib/module_definition'
-require '../azure_mgmt_iot_central/lib/version'
+require_relative '../azure_mgmt_iot_central/lib/module_definition'
+require_relative '../azure_mgmt_iot_central/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_iot_central'

--- a/management/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
+++ b/management/azure_mgmt_iot_hub/azure_mgmt_iot_hub.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_iot_hub/lib/module_definition'
-require '../azure_mgmt_iot_hub/lib/version'
+require_relative '../azure_mgmt_iot_hub/lib/module_definition'
+require_relative '../azure_mgmt_iot_hub/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_iot_hub'

--- a/management/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
+++ b/management/azure_mgmt_key_vault/azure_mgmt_key_vault.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_key_vault/lib/module_definition'
-require '../azure_mgmt_key_vault/lib/version'
+require_relative '../azure_mgmt_key_vault/lib/module_definition'
+require_relative '../azure_mgmt_key_vault/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_key_vault'

--- a/management/azure_mgmt_kubernetes_configuration/azure_mgmt_kubernetes_configuration.gemspec
+++ b/management/azure_mgmt_kubernetes_configuration/azure_mgmt_kubernetes_configuration.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_kubernetes_configuration/lib/module_definition'
-require '../azure_mgmt_kubernetes_configuration/lib/version'
+require_relative '../azure_mgmt_kubernetes_configuration/lib/module_definition'
+require_relative '../azure_mgmt_kubernetes_configuration/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_kubernetes_configuration'

--- a/management/azure_mgmt_kusto/azure_mgmt_kusto.gemspec
+++ b/management/azure_mgmt_kusto/azure_mgmt_kusto.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_kusto/lib/module_definition'
-require '../azure_mgmt_kusto/lib/version'
+require_relative '../azure_mgmt_kusto/lib/module_definition'
+require_relative '../azure_mgmt_kusto/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_kusto'

--- a/management/azure_mgmt_labservices/azure_mgmt_labservices.gemspec
+++ b/management/azure_mgmt_labservices/azure_mgmt_labservices.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_labservices/lib/module_definition'
-require '../azure_mgmt_labservices/lib/version'
+require_relative '../azure_mgmt_labservices/lib/module_definition'
+require_relative '../azure_mgmt_labservices/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_labservices'

--- a/management/azure_mgmt_links/azure_mgmt_links.gemspec
+++ b/management/azure_mgmt_links/azure_mgmt_links.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_links/lib/module_definition'
-require '../azure_mgmt_links/lib/version'
+require_relative '../azure_mgmt_links/lib/module_definition'
+require_relative '../azure_mgmt_links/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_links'

--- a/management/azure_mgmt_locks/azure_mgmt_locks.gemspec
+++ b/management/azure_mgmt_locks/azure_mgmt_locks.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_locks/lib/module_definition'
-require '../azure_mgmt_locks/lib/version'
+require_relative '../azure_mgmt_locks/lib/module_definition'
+require_relative '../azure_mgmt_locks/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_locks'

--- a/management/azure_mgmt_logic/azure_mgmt_logic.gemspec
+++ b/management/azure_mgmt_logic/azure_mgmt_logic.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_logic/lib/module_definition'
-require '../azure_mgmt_logic/lib/version'
+require_relative '../azure_mgmt_logic/lib/module_definition'
+require_relative '../azure_mgmt_logic/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_logic'

--- a/management/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
+++ b/management/azure_mgmt_machine_learning/azure_mgmt_machine_learning.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_machine_learning/lib/module_definition'
-require '../azure_mgmt_machine_learning/lib/version'
+require_relative '../azure_mgmt_machine_learning/lib/module_definition'
+require_relative '../azure_mgmt_machine_learning/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_machine_learning'

--- a/management/azure_mgmt_machine_learning_services/azure_mgmt_machine_learning_services.gemspec
+++ b/management/azure_mgmt_machine_learning_services/azure_mgmt_machine_learning_services.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_machine_learning_services/lib/module_definition'
-require '../azure_mgmt_machine_learning_services/lib/version'
+require_relative '../azure_mgmt_machine_learning_services/lib/module_definition'
+require_relative '../azure_mgmt_machine_learning_services/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_machine_learning_services'

--- a/management/azure_mgmt_maintenance/azure_mgmt_maintenance.gemspec
+++ b/management/azure_mgmt_maintenance/azure_mgmt_maintenance.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_maintenance/lib/module_definition'
-require '../azure_mgmt_maintenance/lib/version'
+require_relative '../azure_mgmt_maintenance/lib/module_definition'
+require_relative '../azure_mgmt_maintenance/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_maintenance'

--- a/management/azure_mgmt_managed_applications/azure_mgmt_managed_applications.gemspec
+++ b/management/azure_mgmt_managed_applications/azure_mgmt_managed_applications.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_managed_applications/lib/module_definition'
-require '../azure_mgmt_managed_applications/lib/version'
+require_relative '../azure_mgmt_managed_applications/lib/module_definition'
+require_relative '../azure_mgmt_managed_applications/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_managed_applications'

--- a/management/azure_mgmt_mariadb/azure_mgmt_mariadb.gemspec
+++ b/management/azure_mgmt_mariadb/azure_mgmt_mariadb.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_mariadb/lib/module_definition'
-require '../azure_mgmt_mariadb/lib/version'
+require_relative '../azure_mgmt_mariadb/lib/module_definition'
+require_relative '../azure_mgmt_mariadb/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_mariadb'

--- a/management/azure_mgmt_marketplace_ordering/azure_mgmt_marketplace_ordering.gemspec
+++ b/management/azure_mgmt_marketplace_ordering/azure_mgmt_marketplace_ordering.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_marketplace_ordering/lib/module_definition'
-require '../azure_mgmt_marketplace_ordering/lib/version'
+require_relative '../azure_mgmt_marketplace_ordering/lib/module_definition'
+require_relative '../azure_mgmt_marketplace_ordering/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_marketplace_ordering'

--- a/management/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
+++ b/management/azure_mgmt_media_services/azure_mgmt_media_services.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_media_services/lib/module_definition'
-require '../azure_mgmt_media_services/lib/version'
+require_relative '../azure_mgmt_media_services/lib/module_definition'
+require_relative '../azure_mgmt_media_services/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_media_services'

--- a/management/azure_mgmt_migrate/azure_mgmt_migrate.gemspec
+++ b/management/azure_mgmt_migrate/azure_mgmt_migrate.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_migrate/lib/module_definition'
-require '../azure_mgmt_migrate/lib/version'
+require_relative '../azure_mgmt_migrate/lib/module_definition'
+require_relative '../azure_mgmt_migrate/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_migrate'

--- a/management/azure_mgmt_mixedreality/azure_mgmt_mixedreality.gemspec
+++ b/management/azure_mgmt_mixedreality/azure_mgmt_mixedreality.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_mixedreality/lib/module_definition'
-require '../azure_mgmt_mixedreality/lib/version'
+require_relative '../azure_mgmt_mixedreality/lib/module_definition'
+require_relative '../azure_mgmt_mixedreality/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_mixedreality'

--- a/management/azure_mgmt_monitor/azure_mgmt_monitor.gemspec
+++ b/management/azure_mgmt_monitor/azure_mgmt_monitor.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_monitor/lib/module_definition'
-require '../azure_mgmt_monitor/lib/version'
+require_relative '../azure_mgmt_monitor/lib/module_definition'
+require_relative '../azure_mgmt_monitor/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_monitor'

--- a/management/azure_mgmt_msi/azure_mgmt_msi.gemspec
+++ b/management/azure_mgmt_msi/azure_mgmt_msi.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_msi/lib/module_definition'
-require '../azure_mgmt_msi/lib/version'
+require_relative '../azure_mgmt_msi/lib/module_definition'
+require_relative '../azure_mgmt_msi/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_msi'

--- a/management/azure_mgmt_mysql/azure_mgmt_mysql.gemspec
+++ b/management/azure_mgmt_mysql/azure_mgmt_mysql.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_mysql/lib/module_definition'
-require '../azure_mgmt_mysql/lib/version'
+require_relative '../azure_mgmt_mysql/lib/module_definition'
+require_relative '../azure_mgmt_mysql/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_mysql'

--- a/management/azure_mgmt_netapp/azure_mgmt_netapp.gemspec
+++ b/management/azure_mgmt_netapp/azure_mgmt_netapp.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_netapp/lib/module_definition'
-require '../azure_mgmt_netapp/lib/version'
+require_relative '../azure_mgmt_netapp/lib/module_definition'
+require_relative '../azure_mgmt_netapp/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_netapp'

--- a/management/azure_mgmt_network/azure_mgmt_network.gemspec
+++ b/management/azure_mgmt_network/azure_mgmt_network.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_network/lib/module_definition'
-require '../azure_mgmt_network/lib/version'
+require_relative '../azure_mgmt_network/lib/module_definition'
+require_relative '../azure_mgmt_network/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_network'

--- a/management/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
+++ b/management/azure_mgmt_notification_hubs/azure_mgmt_notification_hubs.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_notification_hubs/lib/module_definition'
-require '../azure_mgmt_notification_hubs/lib/version'
+require_relative '../azure_mgmt_notification_hubs/lib/module_definition'
+require_relative '../azure_mgmt_notification_hubs/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_notification_hubs'

--- a/management/azure_mgmt_operational_insights/azure_mgmt_operational_insights.gemspec
+++ b/management/azure_mgmt_operational_insights/azure_mgmt_operational_insights.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_operational_insights/lib/module_definition'
-require '../azure_mgmt_operational_insights/lib/version'
+require_relative '../azure_mgmt_operational_insights/lib/module_definition'
+require_relative '../azure_mgmt_operational_insights/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_operational_insights'

--- a/management/azure_mgmt_operations_management/azure_mgmt_operations_management.gemspec
+++ b/management/azure_mgmt_operations_management/azure_mgmt_operations_management.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_operations_management/lib/module_definition'
-require '../azure_mgmt_operations_management/lib/version'
+require_relative '../azure_mgmt_operations_management/lib/module_definition'
+require_relative '../azure_mgmt_operations_management/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_operations_management'

--- a/management/azure_mgmt_peering/azure_mgmt_peering.gemspec
+++ b/management/azure_mgmt_peering/azure_mgmt_peering.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_peering/lib/module_definition'
-require '../azure_mgmt_peering/lib/version'
+require_relative '../azure_mgmt_peering/lib/module_definition'
+require_relative '../azure_mgmt_peering/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_peering'

--- a/management/azure_mgmt_policy/azure_mgmt_policy.gemspec
+++ b/management/azure_mgmt_policy/azure_mgmt_policy.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_policy/lib/module_definition'
-require '../azure_mgmt_policy/lib/version'
+require_relative '../azure_mgmt_policy/lib/module_definition'
+require_relative '../azure_mgmt_policy/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_policy'

--- a/management/azure_mgmt_policy_insights/azure_mgmt_policy_insights.gemspec
+++ b/management/azure_mgmt_policy_insights/azure_mgmt_policy_insights.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_policy_insights/lib/module_definition'
-require '../azure_mgmt_policy_insights/lib/version'
+require_relative '../azure_mgmt_policy_insights/lib/module_definition'
+require_relative '../azure_mgmt_policy_insights/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_policy_insights'

--- a/management/azure_mgmt_portal/azure_mgmt_portal.gemspec
+++ b/management/azure_mgmt_portal/azure_mgmt_portal.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_portal/lib/module_definition'
-require '../azure_mgmt_portal/lib/version'
+require_relative '../azure_mgmt_portal/lib/module_definition'
+require_relative '../azure_mgmt_portal/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_portal'

--- a/management/azure_mgmt_postgresql/azure_mgmt_postgresql.gemspec
+++ b/management/azure_mgmt_postgresql/azure_mgmt_postgresql.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_postgresql/lib/module_definition'
-require '../azure_mgmt_postgresql/lib/version'
+require_relative '../azure_mgmt_postgresql/lib/module_definition'
+require_relative '../azure_mgmt_postgresql/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_postgresql'

--- a/management/azure_mgmt_powerbi_dedicated/azure_mgmt_powerbi_dedicated.gemspec
+++ b/management/azure_mgmt_powerbi_dedicated/azure_mgmt_powerbi_dedicated.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_powerbi_dedicated/lib/module_definition'
-require '../azure_mgmt_powerbi_dedicated/lib/version'
+require_relative '../azure_mgmt_powerbi_dedicated/lib/module_definition'
+require_relative '../azure_mgmt_powerbi_dedicated/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_powerbi_dedicated'

--- a/management/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
+++ b/management/azure_mgmt_powerbi_embedded/azure_mgmt_powerbi_embedded.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_powerbi_embedded/lib/module_definition'
-require '../azure_mgmt_powerbi_embedded/lib/version'
+require_relative '../azure_mgmt_powerbi_embedded/lib/module_definition'
+require_relative '../azure_mgmt_powerbi_embedded/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_powerbi_embedded'

--- a/management/azure_mgmt_privatedns/azure_mgmt_privatedns.gemspec
+++ b/management/azure_mgmt_privatedns/azure_mgmt_privatedns.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_privatedns/lib/module_definition'
-require '../azure_mgmt_privatedns/lib/version'
+require_relative '../azure_mgmt_privatedns/lib/module_definition'
+require_relative '../azure_mgmt_privatedns/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_privatedns'

--- a/management/azure_mgmt_recovery_services/azure_mgmt_recovery_services.gemspec
+++ b/management/azure_mgmt_recovery_services/azure_mgmt_recovery_services.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_recovery_services/lib/module_definition'
-require '../azure_mgmt_recovery_services/lib/version'
+require_relative '../azure_mgmt_recovery_services/lib/module_definition'
+require_relative '../azure_mgmt_recovery_services/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_recovery_services'

--- a/management/azure_mgmt_recovery_services_backup/azure_mgmt_recovery_services_backup.gemspec
+++ b/management/azure_mgmt_recovery_services_backup/azure_mgmt_recovery_services_backup.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_recovery_services_backup/lib/module_definition'
-require '../azure_mgmt_recovery_services_backup/lib/version'
+require_relative '../azure_mgmt_recovery_services_backup/lib/module_definition'
+require_relative '../azure_mgmt_recovery_services_backup/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_recovery_services_backup'

--- a/management/azure_mgmt_recovery_services_site_recovery/azure_mgmt_recovery_services_site_recovery.gemspec
+++ b/management/azure_mgmt_recovery_services_site_recovery/azure_mgmt_recovery_services_site_recovery.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_recovery_services_site_recovery/lib/module_definition'
-require '../azure_mgmt_recovery_services_site_recovery/lib/version'
+require_relative '../azure_mgmt_recovery_services_site_recovery/lib/module_definition'
+require_relative '../azure_mgmt_recovery_services_site_recovery/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_recovery_services_site_recovery'

--- a/management/azure_mgmt_redis/azure_mgmt_redis.gemspec
+++ b/management/azure_mgmt_redis/azure_mgmt_redis.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_redis/lib/module_definition'
-require '../azure_mgmt_redis/lib/version'
+require_relative '../azure_mgmt_redis/lib/module_definition'
+require_relative '../azure_mgmt_redis/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_redis'

--- a/management/azure_mgmt_relay/azure_mgmt_relay.gemspec
+++ b/management/azure_mgmt_relay/azure_mgmt_relay.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_relay/lib/module_definition'
-require '../azure_mgmt_relay/lib/version'
+require_relative '../azure_mgmt_relay/lib/module_definition'
+require_relative '../azure_mgmt_relay/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_relay'

--- a/management/azure_mgmt_reservations/azure_mgmt_reservations.gemspec
+++ b/management/azure_mgmt_reservations/azure_mgmt_reservations.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_reservations/lib/module_definition'
-require '../azure_mgmt_reservations/lib/version'
+require_relative '../azure_mgmt_reservations/lib/module_definition'
+require_relative '../azure_mgmt_reservations/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_reservations'

--- a/management/azure_mgmt_resource_health/azure_mgmt_resource_health.gemspec
+++ b/management/azure_mgmt_resource_health/azure_mgmt_resource_health.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_resource_health/lib/module_definition'
-require '../azure_mgmt_resource_health/lib/version'
+require_relative '../azure_mgmt_resource_health/lib/module_definition'
+require_relative '../azure_mgmt_resource_health/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_resource_health'

--- a/management/azure_mgmt_resourcegraph/azure_mgmt_resourcegraph.gemspec
+++ b/management/azure_mgmt_resourcegraph/azure_mgmt_resourcegraph.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_resourcegraph/lib/module_definition'
-require '../azure_mgmt_resourcegraph/lib/version'
+require_relative '../azure_mgmt_resourcegraph/lib/module_definition'
+require_relative '../azure_mgmt_resourcegraph/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_resourcegraph'

--- a/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
+++ b/management/azure_mgmt_resources/azure_mgmt_resources.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_resources/lib/module_definition'
-require '../azure_mgmt_resources/lib/version'
+require_relative '../azure_mgmt_resources/lib/module_definition'
+require_relative '../azure_mgmt_resources/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_resources'

--- a/management/azure_mgmt_resources_management/azure_mgmt_resources_management.gemspec
+++ b/management/azure_mgmt_resources_management/azure_mgmt_resources_management.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_resources_management/lib/module_definition'
-require '../azure_mgmt_resources_management/lib/version'
+require_relative '../azure_mgmt_resources_management/lib/module_definition'
+require_relative '../azure_mgmt_resources_management/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_resources_management'

--- a/management/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
+++ b/management/azure_mgmt_scheduler/azure_mgmt_scheduler.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_scheduler/lib/module_definition'
-require '../azure_mgmt_scheduler/lib/version'
+require_relative '../azure_mgmt_scheduler/lib/module_definition'
+require_relative '../azure_mgmt_scheduler/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_scheduler'

--- a/management/azure_mgmt_search/azure_mgmt_search.gemspec
+++ b/management/azure_mgmt_search/azure_mgmt_search.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_search/lib/module_definition'
-require '../azure_mgmt_search/lib/version'
+require_relative '../azure_mgmt_search/lib/module_definition'
+require_relative '../azure_mgmt_search/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_search'

--- a/management/azure_mgmt_security/azure_mgmt_security.gemspec
+++ b/management/azure_mgmt_security/azure_mgmt_security.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_security/lib/module_definition'
-require '../azure_mgmt_security/lib/version'
+require_relative '../azure_mgmt_security/lib/module_definition'
+require_relative '../azure_mgmt_security/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_security'

--- a/management/azure_mgmt_security_insights/azure_mgmt_security_insights.gemspec
+++ b/management/azure_mgmt_security_insights/azure_mgmt_security_insights.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_security_insights/lib/module_definition'
-require '../azure_mgmt_security_insights/lib/version'
+require_relative '../azure_mgmt_security_insights/lib/module_definition'
+require_relative '../azure_mgmt_security_insights/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_security_insights'

--- a/management/azure_mgmt_serialconsole/azure_mgmt_serialconsole.gemspec
+++ b/management/azure_mgmt_serialconsole/azure_mgmt_serialconsole.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_serialconsole/lib/module_definition'
-require '../azure_mgmt_serialconsole/lib/version'
+require_relative '../azure_mgmt_serialconsole/lib/module_definition'
+require_relative '../azure_mgmt_serialconsole/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_serialconsole'

--- a/management/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
+++ b/management/azure_mgmt_service_bus/azure_mgmt_service_bus.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_service_bus/lib/module_definition'
-require '../azure_mgmt_service_bus/lib/version'
+require_relative '../azure_mgmt_service_bus/lib/module_definition'
+require_relative '../azure_mgmt_service_bus/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_service_bus'

--- a/management/azure_mgmt_service_fabric/azure_mgmt_service_fabric.gemspec
+++ b/management/azure_mgmt_service_fabric/azure_mgmt_service_fabric.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_service_fabric/lib/module_definition'
-require '../azure_mgmt_service_fabric/lib/version'
+require_relative '../azure_mgmt_service_fabric/lib/module_definition'
+require_relative '../azure_mgmt_service_fabric/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_service_fabric'

--- a/management/azure_mgmt_signalr/azure_mgmt_signalr.gemspec
+++ b/management/azure_mgmt_signalr/azure_mgmt_signalr.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_signalr/lib/module_definition'
-require '../azure_mgmt_signalr/lib/version'
+require_relative '../azure_mgmt_signalr/lib/module_definition'
+require_relative '../azure_mgmt_signalr/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_signalr'

--- a/management/azure_mgmt_signlr/azure_mgmt_signlr.gemspec
+++ b/management/azure_mgmt_signlr/azure_mgmt_signlr.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_signlr/lib/module_definition'
-require '../azure_mgmt_signlr/lib/version'
+require_relative '../azure_mgmt_signlr/lib/module_definition'
+require_relative '../azure_mgmt_signlr/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_signlr'

--- a/management/azure_mgmt_sql/azure_mgmt_sql.gemspec
+++ b/management/azure_mgmt_sql/azure_mgmt_sql.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_sql/lib/module_definition'
-require '../azure_mgmt_sql/lib/version'
+require_relative '../azure_mgmt_sql/lib/module_definition'
+require_relative '../azure_mgmt_sql/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_sql'

--- a/management/azure_mgmt_sqlvirtualmachine/azure_mgmt_sqlvirtualmachine.gemspec
+++ b/management/azure_mgmt_sqlvirtualmachine/azure_mgmt_sqlvirtualmachine.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_sqlvirtualmachine/lib/module_definition'
-require '../azure_mgmt_sqlvirtualmachine/lib/version'
+require_relative '../azure_mgmt_sqlvirtualmachine/lib/module_definition'
+require_relative '../azure_mgmt_sqlvirtualmachine/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_sqlvirtualmachine'

--- a/management/azure_mgmt_stor_simple8000_series/azure_mgmt_stor_simple8000_series.gemspec
+++ b/management/azure_mgmt_stor_simple8000_series/azure_mgmt_stor_simple8000_series.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_stor_simple8000_series/lib/module_definition'
-require '../azure_mgmt_stor_simple8000_series/lib/version'
+require_relative '../azure_mgmt_stor_simple8000_series/lib/module_definition'
+require_relative '../azure_mgmt_stor_simple8000_series/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_stor_simple8000_series'

--- a/management/azure_mgmt_storage/azure_mgmt_storage.gemspec
+++ b/management/azure_mgmt_storage/azure_mgmt_storage.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_storage/lib/module_definition'
-require '../azure_mgmt_storage/lib/version'
+require_relative '../azure_mgmt_storage/lib/module_definition'
+require_relative '../azure_mgmt_storage/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_storage'

--- a/management/azure_mgmt_storagecache/azure_mgmt_storagecache.gemspec
+++ b/management/azure_mgmt_storagecache/azure_mgmt_storagecache.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_storagecache/lib/module_definition'
-require '../azure_mgmt_storagecache/lib/version'
+require_relative '../azure_mgmt_storagecache/lib/module_definition'
+require_relative '../azure_mgmt_storagecache/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_storagecache'

--- a/management/azure_mgmt_storagesync/azure_mgmt_storagesync.gemspec
+++ b/management/azure_mgmt_storagesync/azure_mgmt_storagesync.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_storagesync/lib/module_definition'
-require '../azure_mgmt_storagesync/lib/version'
+require_relative '../azure_mgmt_storagesync/lib/module_definition'
+require_relative '../azure_mgmt_storagesync/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_storagesync'

--- a/management/azure_mgmt_stream_analytics/azure_mgmt_stream_analytics.gemspec
+++ b/management/azure_mgmt_stream_analytics/azure_mgmt_stream_analytics.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_stream_analytics/lib/module_definition'
-require '../azure_mgmt_stream_analytics/lib/version'
+require_relative '../azure_mgmt_stream_analytics/lib/module_definition'
+require_relative '../azure_mgmt_stream_analytics/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_stream_analytics'

--- a/management/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
+++ b/management/azure_mgmt_subscriptions/azure_mgmt_subscriptions.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_subscriptions/lib/module_definition'
-require '../azure_mgmt_subscriptions/lib/version'
+require_relative '../azure_mgmt_subscriptions/lib/module_definition'
+require_relative '../azure_mgmt_subscriptions/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_subscriptions'

--- a/management/azure_mgmt_support/azure_mgmt_support.gemspec
+++ b/management/azure_mgmt_support/azure_mgmt_support.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_support/lib/module_definition'
-require '../azure_mgmt_support/lib/version'
+require_relative '../azure_mgmt_support/lib/module_definition'
+require_relative '../azure_mgmt_support/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_support'

--- a/management/azure_mgmt_synapse/azure_mgmt_synapse.gemspec
+++ b/management/azure_mgmt_synapse/azure_mgmt_synapse.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_synapse/lib/module_definition'
-require '../azure_mgmt_synapse/lib/version'
+require_relative '../azure_mgmt_synapse/lib/module_definition'
+require_relative '../azure_mgmt_synapse/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_synapse'

--- a/management/azure_mgmt_time_series_insights/azure_mgmt_time_series_insights.gemspec
+++ b/management/azure_mgmt_time_series_insights/azure_mgmt_time_series_insights.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_time_series_insights/lib/module_definition'
-require '../azure_mgmt_time_series_insights/lib/version'
+require_relative '../azure_mgmt_time_series_insights/lib/module_definition'
+require_relative '../azure_mgmt_time_series_insights/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_time_series_insights'

--- a/management/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
+++ b/management/azure_mgmt_traffic_manager/azure_mgmt_traffic_manager.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_traffic_manager/lib/module_definition'
-require '../azure_mgmt_traffic_manager/lib/version'
+require_relative '../azure_mgmt_traffic_manager/lib/module_definition'
+require_relative '../azure_mgmt_traffic_manager/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_traffic_manager'

--- a/management/azure_mgmt_vmware_cloudsimple/azure_mgmt_vmware_cloudsimple.gemspec
+++ b/management/azure_mgmt_vmware_cloudsimple/azure_mgmt_vmware_cloudsimple.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_vmware_cloudsimple/lib/module_definition'
-require '../azure_mgmt_vmware_cloudsimple/lib/version'
+require_relative '../azure_mgmt_vmware_cloudsimple/lib/module_definition'
+require_relative '../azure_mgmt_vmware_cloudsimple/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_vmware_cloudsimple'

--- a/management/azure_mgmt_web/azure_mgmt_web.gemspec
+++ b/management/azure_mgmt_web/azure_mgmt_web.gemspec
@@ -5,8 +5,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require '../azure_mgmt_web/lib/module_definition'
-require '../azure_mgmt_web/lib/version'
+require_relative '../azure_mgmt_web/lib/module_definition'
+require_relative '../azure_mgmt_web/lib/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'azure_mgmt_web'


### PR DESCRIPTION
`require` loads files based upon a load path.
`require_relative` loads files based upon the location of the current file.

While `..` is discouraged from use in `require_relative`, it just doesn't make sense in terms of `require` and a load path.

I found this issue when pointing my `Gemfile` at GitHub and my ruby couldn’t make sense of the gemspecs.

If there is a template to update instead, just point me in that direction.

thanks