### PR TITLE
Bump thor dependency to 1.2

### DIFF
--- a/azure.gemspec
+++ b/azure.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mime-types',              ['>= 1', '< 4.0'])  # vagrant-share and other stuff relies on 1
   s.add_runtime_dependency('nokogiri',                '~> 1.6')
   s.add_runtime_dependency('systemu',                 '~> 2.6')
-  s.add_runtime_dependency('thor',                    '~> 0.19')
+  s.add_runtime_dependency('thor',                    '~> 1.2')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')


### PR DESCRIPTION
This will allow us to update some other projects in our rails application such as bundler-audit which requires a newer version of Thor. 

The only impacted file in the repo is `bin/pfxer` which is not effected by updating to Thor 1.2. 

I do not have a publish settings file to test with, but I made a mock XML file and confirmed that the output was the same before and after the upgrade to Thor. 
