### PR TITLE
use already json parsed error model in body in http_operation_error

### DIFF
--- a/runtime/ms_rest/lib/ms_rest/http_operation_error.rb
+++ b/runtime/ms_rest/lib/ms_rest/http_operation_error.rb
@@ -56,7 +56,7 @@ module MsRest
     end
     
     def to_json(*a)
-      res_dict = response ? { body: response.body, headers: response.headers, status: response.status } : nil
+      res_dict = response ? { body: ( @body ? @body : response.body ), headers: response.headers, status: response.status } : nil
       {message: @msg, request: request, response: res_dict}.to_json(*a)
     end
     


### PR DESCRIPTION
## Issue

https://github.com/Azure/azure-sdk-for-ruby/blob/9175ace5230a9b63be963ebf4cb4ee42e08f8804/runtime/ms_rest_azure/lib/ms_rest_azure/azure_service_client.rb#L112

returns `AzureOperationError` object which should contain following values
```
unless @body.nil?
  @error_message = @body['error']['message']
  @error_code = @body['error']['code']
  @msg = "#{@msg}: #{@error_code}: #{@error_message}"
end
```
but `@body` is not properly json parsed and this causes `@error_message` and `@error_code` to be nil


## Example

https://github.com/Azure/azure-sdk-for-ruby/blob/9175ace5230a9b63be963ebf4cb4ee42e08f8804/runtime/ms_rest_azure/lib/ms_rest_azure/polling_state.rb#L110

Not just `AzureOperationError`, all `HttpOperationError` takes already parsed error model as 3rd arguments if exists

https://github.com/Azure/azure-sdk-for-ruby/blob/9175ace5230a9b63be963ebf4cb4ee42e08f8804/runtime/ms_rest/lib/ms_rest/http_operation_error.rb#L59

But in `res_dict` is referring `response.body` which might not be properly parsed and this is why code block above `@body['error']['message']` returns nil


## Suggested Solution

if `@body` exists, use that value in `res_dict`
```
res_dict = response ? { body: ( @body ? @body : response.body ), headers: response.headers, status: response.status } : nil
```