### PR TITLE
update faraday dependency

### DIFF
--- a/runtime/ms_rest/ms_rest.gemspec
+++ b/runtime/ms_rest/ms_rest.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'timeliness', '~> 0.3.10'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 3.0.0'
 end

--- a/runtime/ms_rest_azure/ms_rest_azure.gemspec
+++ b/runtime/ms_rest_azure/ms_rest_azure.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.3'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 3.0.0'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_runtime_dependency 'ms_rest', '~> 0.7.6'
 end


### PR DESCRIPTION
Hi, one of my project is using `azure_mgmt_network` and `azure_mgmt_compute` and because of that I can't upgrade faraday 😢.

After reading the [upgrading guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) I think it should be fine to just bump the version because this project isn't using the [`faraday_middleware`](https://github.com/lostisland/faraday_middleware#%EF%B8%8F-deprecation-warning-%EF%B8%8F). 